### PR TITLE
zkASM: restore `Inst::Mov` tests

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit_tests.rs
@@ -35,27 +35,23 @@ fn test_zkasm_binemit() {
         "SP - 16 => SP\n  :JMP(RR)",
     ));
     // TODO: a test with `rets`.
+    insns.push(TestUnit::new(
+        Inst::Mov {
+            rd: writable_fa0(),
+            rm: fa1(),
+            ty: F32,
+        },
+        "fa1 => fa0", // FIXME: wrong register names!
+    ));
 
-    //
-    // insns.push(TestUnit::new(
-    //     Inst::Mov {
-    //         rd: writable_fa0(),
-    //         rm: fa1(),
-    //         ty: F32,
-    //     },
-    //     "fmv.s fa0,fa1",
-    //     0x20b58553,
-    // ));
-    //
-    // insns.push(TestUnit::new(
-    //     Inst::Mov {
-    //         rd: writable_fa0(),
-    //         rm: fa1(),
-    //         ty: F64,
-    //     },
-    //     "fmv.d fa0,fa1",
-    //     0x22b58553,
-    // ));
+    insns.push(TestUnit::new(
+        Inst::Mov {
+            rd: writable_fa0(),
+            rm: fa1(),
+            ty: F64,
+        },
+        "fa1 => fa0", // FIXME: wrong register names!
+    ));
     //
     // insns.push(TestUnit::new(
     //     Inst::AluRRImm12 {
@@ -2086,7 +2082,7 @@ fn test_zkasm_binemit() {
         let actual_printing = unit
             .inst
             .print_with_state(&mut EmitState::default(), &mut AllocationConsumer::new(&[]));
-        assert_eq!(unit.assembly, actual_printing);
+        assert_eq!(unit.assembly.trim(), actual_printing.trim());
         let mut buffer = MachBuffer::new();
         unit.inst
             .emit(&[], &mut buffer, &emit_info, &mut Default::default());
@@ -2094,7 +2090,7 @@ fn test_zkasm_binemit() {
         let actual_encoding = std::str::from_utf8(buffer.data())
             .expect("mach buffer is expected to contain assembly as valid utf-8");
 
-        assert_eq!(actual_encoding.trim(), unit.assembly);
+        assert_eq!(actual_encoding.trim(), unit.assembly.trim());
     }
 }
 

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -1607,9 +1607,9 @@ impl Inst {
                 stack_bytes_to_pop,
             } => {
                 let mut s = if stack_bytes_to_pop == 0 {
-                    ":JMP(RR)".to_string()
+                    "  :JMP(RR)".to_string()
                 } else {
-                    format!("SP - {stack_bytes_to_pop} => SP\n  :JMP(RR)")
+                    format!("  SP - {stack_bytes_to_pop} => SP\n  :JMP(RR)")
                 };
 
                 let mut empty_allocs = AllocationConsumer::default();
@@ -1749,15 +1749,7 @@ impl Inst {
             &MInst::Mov { rd, rm, ty } => {
                 let rd = format_reg(rd.to_reg(), allocs);
                 let rm = format_reg(rm, allocs);
-
-                let op = match ty {
-                    F32 => "fmv.s",
-                    F64 => "fmv.d",
-                    ty if ty.is_vector() => "vmv1r.v",
-                    _ => "mv",
-                };
-
-                format!("{op} {rd},{rm}")
+                format!("{rm} => {rd}")
             }
             &MInst::MovFromPReg { rd, rm } => {
                 let rd = format_reg(rd.to_reg(), allocs);


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
