### PR TITLE
zkasm: split AdjustSp to separate variants for Reserve and Release stack space

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/abi.rs
+++ b/cranelift/codegen/src/isa/zkasm/abi.rs
@@ -328,8 +328,15 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         if amount == 0 {
             return insts;
         }
-        insts.push(Inst::AdjustSp {
-            amount: amount as i64,
+        // FIXME: is this right/sufficient for stack growing up
+        insts.push(if amount < 0 {
+            Inst::ReserveSp {
+                amount: -amount as u64,
+            }
+        } else {
+            Inst::ReleaseSp {
+                amount: amount as u64,
+            }
         });
         insts
     }
@@ -396,11 +403,9 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let mut insts = SmallVec::new();
 
         if frame_layout.setup_area_size > 0 {
-            // add  sp,sp,-16    ;; alloc stack space for fp.
-            // sd   ra,8(sp)     ;; save ra.
-            // sd   fp,0(sp)     ;; store old fp.
-            // mv   fp,sp        ;; set fp to sp.
-            insts.push(Inst::AdjustSp { amount: -1 });
+            insts.push(Inst::ReserveSp {
+                amount: frame_layout.setup_area_size.into(),
+            });
             insts.push(Self::gen_store_stack(
                 StackAMode::SPOffset(0, I64),
                 link_reg(),
@@ -448,7 +453,9 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             //     writable_fp_reg(),
             //     I64,
             // ));
-            insts.push(Inst::AdjustSp { amount: 1 });
+            insts.push(Inst::ReleaseSp {
+                amount: frame_layout.setup_area_size.into(),
+            });
         }
 
         if call_conv == isa::CallConv::Tail && frame_layout.stack_args_size > 0 {
@@ -507,25 +514,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
 
     fn gen_clobber_save(
         _call_conv: isa::CallConv,
-        flags: &settings::Flags,
+        _flags: &settings::Flags,
         frame_layout: &FrameLayout,
     ) -> SmallVec<[Self::I; 16]> {
         let mut insts = SmallVec::new();
-        // Adjust the stack pointer downward for clobbers and the function fixed
+        // Adjust the stack pointer upward for clobbers and the function fixed
         // frame (spillslots and storage slots).
         let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
-        // Each stack slot is 64 bit and can fit a u8 value.
+        // The stack (and memory in general) in zkASM is addressed in slots, rather than bytes.
+        // Adjust accordingly.
         let stack_size = stack_size / 8;
-        if flags.unwind_info() && frame_layout.setup_area_size > 0 {
-            // The *unwind* frame (but not the actual frame) starts at the
-            // clobbers, just below the saved FP/LR pair.
-            // insts.push(Inst::Unwind {
-            //     inst: UnwindInst::DefineNewFrame {
-            //         offset_downward_to_clobbers: frame_layout.clobber_size,
-            //         offset_upward_to_caller_sp: frame_layout.setup_area_size,
-            //     },
-            // });
-        }
         // Store each clobbered register in order at offsets from SP,
         // placing them above the fixed frame slots.
         if stack_size > 0 {
@@ -538,14 +536,6 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     RegClass::Float => F64,
                     RegClass::Vector => unimplemented!("Vector Clobber Saves"),
                 };
-                if flags.unwind_info() {
-                    // insts.push(Inst::Unwind {
-                    //     inst: UnwindInst::SaveReg {
-                    //         clobber_offset: frame_layout.clobber_size - cur_offset,
-                    //         reg: r_reg,
-                    //     },
-                    // });
-                }
                 insts.push(Self::gen_store_stack(
                     StackAMode::SPOffset(-(cur_offset as i64), ty),
                     real_reg_to_reg(reg.to_reg()),
@@ -553,8 +543,8 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 ));
                 cur_offset += 1
             }
-            insts.push(Inst::AdjustSp {
-                amount: -(stack_size as i64),
+            insts.push(Inst::ReserveSp {
+                amount: stack_size.into(),
             });
         }
         insts
@@ -568,10 +558,11 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let mut insts = SmallVec::new();
         let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
         // Each stack slot is 64 bit and can fit a u8 value.
+        // FIXME(nagisa): WHAT DOES THIS MEAA~~~AAAN????
         let stack_size = stack_size / 8;
         if stack_size > 0 {
-            insts.push(Inst::AdjustSp {
-                amount: stack_size as i64,
+            insts.push(Inst::ReleaseSp {
+                amount: stack_size.into(),
             });
         }
         let mut cur_offset = 1;

--- a/cranelift/codegen/src/isa/zkasm/inst.isle
+++ b/cranelift/codegen/src/isa/zkasm/inst.isle
@@ -52,7 +52,7 @@
       (args VecArgPair))
 
     (Ret (rets VecRetPair)
-         (stack_bytes_to_pop u32))
+         (stack_bytes_to_pop u64))
 
     (Extend
       (rd WritableReg)
@@ -61,8 +61,11 @@
       (from_bits u8)
       (to_bits u8))
 
-    (AdjustSp
-      (amount i64))
+    ;; Adjust the stack pointer as necessary.
+    (ReserveSp
+      (amount u64))
+    (ReleaseSp
+      (amount u64))
 
     (Call
       (info BoxCallInfo))

--- a/cranelift/codegen/src/isa/zkasm/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit_tests.rs
@@ -32,7 +32,7 @@ fn test_zkasm_binemit() {
             rets: vec![],
             stack_bytes_to_pop: 16,
         },
-        "SP - 16 => SP\n  :JMP(RR)",
+        "SP - 2 => SP\n  :JMP(RR)",
     ));
     // TODO: a test with `rets`.
     insns.push(TestUnit::new(

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -327,7 +327,10 @@ fn zkasm_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
             collector.reg_use(rn);
             collector.reg_def(rd);
         }
-        &Inst::AdjustSp { .. } => {}
+
+        &Inst::ReserveSp { .. } => {}
+        &Inst::ReleaseSp { .. } => {}
+
         &Inst::Call { ref info } => {
             for u in &info.uses {
                 collector.reg_fixed_use(u.vreg, u.preg);
@@ -1033,10 +1036,16 @@ impl Inst {
                 ref rets,
                 stack_bytes_to_pop,
             } => {
-                let mut s = if stack_bytes_to_pop == 0 {
-                    "  :JMP(RR)".to_string()
+                let mut s = if stack_bytes_to_pop != 0 {
+                    format!(
+                        "  {}\n  :JMP(RR)",
+                        Inst::ReleaseSp {
+                            amount: stack_bytes_to_pop
+                        }
+                        .print_with_state(_state, allocs)
+                    )
                 } else {
-                    format!("  SP - {stack_bytes_to_pop} => SP\n  :JMP(RR)")
+                    "  :JMP(RR)".to_string()
                 };
 
                 let mut empty_allocs = AllocationConsumer::default();
@@ -1048,7 +1057,7 @@ impl Inst {
                 s
             }
 
-            &MInst::Extend {
+            &Inst::Extend {
                 rd,
                 rn,
                 signed,
@@ -1065,15 +1074,22 @@ impl Inst {
                     format!("slli {rd},{rn},{shift_bits}; {op} {rd},{rd},{shift_bits}")
                 };
             }
-            &MInst::AdjustSp { amount } => {
-                format!("{} sp,{:+}", "add", amount)
+            &Inst::ReserveSp { amount } => {
+                // FIXME: conversion methods
+                let amount = amount.checked_div(8).unwrap();
+                format!("  SP + {} => SP", amount)
             }
-            &MInst::Call { ref info } => format!("call {}", info.dest.display(None)),
-            &MInst::CallInd { ref info } => {
+            &Inst::ReleaseSp { amount } => {
+                // FIXME: conversion methods
+                let amount = amount.checked_div(8).unwrap();
+                format!("  SP - {} => SP", amount)
+            }
+            &Inst::Call { ref info } => format!("call {}", info.dest.display(None)),
+            &Inst::CallInd { ref info } => {
                 let rd = format_reg(info.rn, allocs);
                 format!("callind {}", rd)
             }
-            &MInst::ReturnCall {
+            &Inst::ReturnCall {
                 ref callee,
                 ref info,
             } => {
@@ -1088,7 +1104,7 @@ impl Inst {
                 }
                 s
             }
-            &MInst::ReturnCallInd { callee, ref info } => {
+            &Inst::ReturnCallInd { callee, ref info } => {
                 let callee = format_reg(callee, allocs);
                 let mut s = format!(
                     "return_call_ind {callee} old_stack_arg_size:{} new_stack_arg_size:{}",
@@ -1101,10 +1117,10 @@ impl Inst {
                 }
                 s
             }
-            &MInst::TrapIf { test, trap_code } => {
+            &Inst::TrapIf { test, trap_code } => {
                 format!("trap_if {},{}", format_reg(test, allocs), trap_code,)
             }
-            &MInst::TrapIfC {
+            &Inst::TrapIfC {
                 rs1,
                 rs2,
                 cc,
@@ -1114,10 +1130,10 @@ impl Inst {
                 let rs2 = format_reg(rs2, allocs);
                 format!("trap_ifc {}##({} {} {})", trap_code, rs1, cc, rs2)
             }
-            &MInst::Jal { dest, .. } => {
+            &Inst::Jal { dest, .. } => {
                 format!("{} {}", "j", dest)
             }
-            &MInst::CondBr {
+            &Inst::CondBr {
                 taken,
                 not_taken,
                 kind,
@@ -1140,7 +1156,7 @@ impl Inst {
                     x
                 }
             }
-            &MInst::LoadExtName {
+            &Inst::LoadExtName {
                 rd,
                 ref name,
                 offset,
@@ -1148,26 +1164,26 @@ impl Inst {
                 let rd = format_reg(rd.to_reg(), allocs);
                 format!("load_sym {},{}{:+}", rd, name.display(None), offset)
             }
-            &MInst::LoadAddr { ref rd, ref mem } => {
+            &Inst::LoadAddr { ref rd, ref mem } => {
                 let rs = mem.to_string_with_alloc(allocs);
                 let rd = format_reg(rd.to_reg(), allocs);
                 format!("load_addr {},{}", rd, rs)
             }
-            &MInst::VirtualSPOffsetAdj { amount } => {
+            &Inst::VirtualSPOffsetAdj { amount } => {
                 format!("virtual_sp_offset_adj {:+}", amount)
             }
-            &MInst::Mov { rd, rm, ty } => {
+            &Inst::Mov { rd, rm, ty } => {
                 let rd = format_reg(rd.to_reg(), allocs);
                 let rm = format_reg(rm, allocs);
                 format!("{rm} => {rd}")
             }
-            &MInst::MovFromPReg { rd, rm } => {
+            &Inst::MovFromPReg { rd, rm } => {
                 let rd = format_reg(rd.to_reg(), allocs);
                 debug_assert!([px_reg(2), px_reg(8)].contains(&rm));
                 let rm = reg_name(Reg::from(rm));
                 format!("mv {},{}", rd, rm)
             }
-            &MInst::Select {
+            &Inst::Select {
                 ref dst,
                 condition,
                 ref x,
@@ -1181,9 +1197,9 @@ impl Inst {
                 let dst = format_regs(&dst[..], allocs);
                 format!("select_{} {},{},{}##condition={}", ty, dst, x, y, condition)
             }
-            &MInst::Udf { trap_code } => format!("udf##trap_code={}", trap_code),
-            &MInst::EBreak {} => String::from("ebreak"),
-            &MInst::ECall {} => String::from("ecall"),
+            &Inst::Udf { trap_code } => format!("udf##trap_code={}", trap_code),
+            &Inst::EBreak {} => String::from("ebreak"),
+            &Inst::ECall {} => String::from("ecall"),
         }
     }
 }

--- a/cranelift/zkasm_data/generated/add.zkasm
+++ b/cranelift/zkasm_data/generated/add.zkasm
@@ -3,13 +3,13 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  SP + 1 => SP
+  SP + 2 => SP
   RR :MSTORE(SP)
   2 + 3 => A
   5 => B
   B :ASSERT
   $ => RR :MLOAD(SP)
-  SP - 1 => SP
+  SP - 2 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/add_func.zkasm
+++ b/cranelift/zkasm_data/generated/add_func.zkasm
@@ -3,7 +3,7 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  SP + 1 => SP
+  SP + 2 => SP
   RR :MSTORE(SP)
   2 => A
   3 => B
@@ -12,7 +12,7 @@ function_1:
   5 => B
   B :ASSERT
   $ => RR :MLOAD(SP)
-  SP - 1 => SP
+  SP - 2 => SP
   :JMP(RR)
 function_2:
   $ => A :ADD

--- a/cranelift/zkasm_data/generated/counter.zkasm
+++ b/cranelift/zkasm_data/generated/counter.zkasm
@@ -3,7 +3,7 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  SP + 1 => SP
+  SP + 2 => SP
   RR :MSTORE(SP)
   0 => A
   :JMP(L1_1)
@@ -18,7 +18,7 @@ L1_3:
   10 => B
   B :ASSERT
   $ => RR :MLOAD(SP)
-  SP - 1 => SP
+  SP - 2 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/fibonacci.zkasm
+++ b/cranelift/zkasm_data/generated/fibonacci.zkasm
@@ -3,9 +3,9 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  SP + 1 => SP
+  SP + 2 => SP
   RR :MSTORE(SP)
-  SP + 1 => SP
+  SP + 0 => SP
   0 => A
   A => D
   0 => A
@@ -30,9 +30,9 @@ L1_3:
   89 => B
   C => A
   B :ASSERT
-  SP - 1 => SP
+  SP - 0 => SP
   $ => RR :MLOAD(SP)
-  SP - 1 => SP
+  SP - 2 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/locals.zkasm
+++ b/cranelift/zkasm_data/generated/locals.zkasm
@@ -3,13 +3,13 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  SP + 1 => SP
+  SP + 2 => SP
   RR :MSTORE(SP)
   2 + 3 => A
   5 => B
   B :ASSERT
   $ => RR :MLOAD(SP)
-  SP - 1 => SP
+  SP - 2 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/locals_simple.zkasm
+++ b/cranelift/zkasm_data/generated/locals_simple.zkasm
@@ -3,13 +3,13 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  SP + 1 => SP
+  SP + 2 => SP
   RR :MSTORE(SP)
   2 => A
   2 => B
   B :ASSERT
   $ => RR :MLOAD(SP)
-  SP - 1 => SP
+  SP - 2 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)


### PR DESCRIPTION
Since now we're looking at supporting an architecture with stack growth in an unusual direction, it is better to be intentional about what semantic purpose these have, and having them as separate instructions makes it somewhat easier to think about this.