### PR TITLE
zkasm: improve handling of register clobbering and prologue/epilogue generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -754,6 +754,7 @@ jobs:
     name: Record the result of testing and building steps
     runs-on: ubuntu-latest
     needs:
+      - test_zkasm
       - test
       - build
       - rustfmt

--- a/cranelift/codegen/src/isa/zkasm/abi.rs
+++ b/cranelift/codegen/src/isa/zkasm/abi.rs
@@ -53,7 +53,7 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
 
     /// Return required stack alignment in bytes.
     fn stack_align(_call_conv: isa::CallConv) -> u32 {
-        1
+        8
     }
 
     fn compute_arg_locs<'a, I>(

--- a/cranelift/codegen/src/isa/zkasm/abi.rs
+++ b/cranelift/codegen/src/isa/zkasm/abi.rs
@@ -13,7 +13,6 @@ use crate::isa::zkasm::{inst::EmitState, inst::*};
 use crate::isa::CallConv;
 use crate::machinst::*;
 
-use crate::ir::types::I8;
 use crate::ir::LibCall;
 use crate::ir::Signature;
 use crate::isa::zkasm::settings::Flags;
@@ -374,15 +373,10 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
                 amount: frame_layout.setup_area_size.into(),
             });
             insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(0, I64),
+                StackAMode::SPOffset(-1, I64),
                 link_reg(),
                 I64,
             ));
-            // insts.push(Self::gen_store_stack(
-            //     StackAMode::SPOffset(0, I64),
-            //     fp_reg(),
-            //     I64,
-            // ));
         }
 
         insts
@@ -398,24 +392,17 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
 
         if frame_layout.setup_area_size > 0 {
             insts.push(Self::gen_load_stack(
-                StackAMode::SPOffset(0, I64),
+                StackAMode::SPOffset(-1, I64),
                 writable_link_reg(),
                 I64,
             ));
-            // insts.push(Self::gen_load_stack(
-            //     StackAMode::SPOffset(0, I64),
-            //     writable_fp_reg(),
-            //     I64,
-            // ));
             insts.push(Inst::ReleaseSp {
                 amount: frame_layout.setup_area_size.into(),
             });
         }
 
-        if call_conv == isa::CallConv::Tail && frame_layout.stack_args_size > 0 {
-            insts.extend(Self::gen_sp_reg_adjust(
-                frame_layout.stack_args_size.try_into().unwrap(),
-            ));
+        if call_conv == isa::CallConv::Tail {
+            todo!()
         }
         insts.push(Inst::Ret {
             rets: vec![],
@@ -425,45 +412,17 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
         insts
     }
 
-    fn gen_probestack(insts: &mut SmallInstVec<Self::I>, frame_size: u32) {
-        insts.extend(Inst::load_constant_u32(
-            writable_a0(),
-            frame_size as u64,
-            &mut |_| writable_a0(),
-        ));
-        insts.push(Inst::Call {
-            info: Box::new(CallInfo {
-                dest: ExternalName::LibCall(LibCall::Probestack),
-                uses: smallvec![CallArgPair {
-                    vreg: a0(),
-                    preg: a0(),
-                }],
-                defs: smallvec![],
-                clobbers: PRegSet::empty(),
-                opcode: Opcode::Call,
-                callee_callconv: CallConv::SystemV,
-                caller_callconv: CallConv::SystemV,
-                callee_pop_size: 0,
-            }),
-        });
+    fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _frame_size: u32) {
+        todo!()
     }
 
     fn gen_inline_probestack(
-        insts: &mut SmallInstVec<Self::I>,
-        call_conv: isa::CallConv,
-        frame_size: u32,
-        guard_size: u32,
+        _insts: &mut SmallInstVec<Self::I>,
+        _call_conv: isa::CallConv,
+        _frame_size: u32,
+        _guard_size: u32,
     ) {
-        // Unroll at most n consecutive probes, before falling back to using a loop
-        const PROBE_MAX_UNROLL: u32 = 3;
-        // Number of probes that we need to perform
-        let probe_count = align_to(frame_size, guard_size) / guard_size;
-
-        if probe_count <= PROBE_MAX_UNROLL {
-            Self::gen_probestack_unroll(insts, guard_size, probe_count)
-        } else {
-            Self::gen_probestack_loop(insts, call_conv, guard_size, probe_count)
-        }
+        todo!()
     }
 
     fn gen_clobber_save(
@@ -475,14 +434,13 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
         // Adjust the stack pointer upward for clobbers and the function fixed
         // frame (spillslots and storage slots).
         let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
-        // The stack (and memory in general) in zkASM is addressed in slots, rather than bytes.
-        // Adjust accordingly.
-        let stack_size = stack_size / 8;
         // Store each clobbered register in order at offsets from SP,
         // placing them above the fixed frame slots.
         if stack_size > 0 {
-            // since we use fp, we didn't need use UnwindInst::StackAlloc.
-            let mut cur_offset = 1;
+            insts.push(Inst::ReserveSp {
+                amount: stack_size.into(),
+            });
+            let mut cur_offset = -1;
             for reg in &frame_layout.clobbered_callee_saves {
                 let r_reg = reg.to_reg();
                 let ty = match r_reg.class() {
@@ -491,15 +449,12 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
                     RegClass::Vector => unimplemented!("Vector Clobber Saves"),
                 };
                 insts.push(Self::gen_store_stack(
-                    StackAMode::SPOffset(-(cur_offset as i64), ty),
+                    StackAMode::SPOffset(cur_offset, ty),
                     real_reg_to_reg(reg.to_reg()),
                     ty,
                 ));
-                cur_offset += 1
+                cur_offset -= 1
             }
-            insts.push(Inst::ReserveSp {
-                amount: stack_size.into(),
-            });
         }
         insts
     }
@@ -511,28 +466,25 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
     ) -> SmallVec<[Self::I; 16]> {
         let mut insts = SmallVec::new();
         let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
-        // Each stack slot is 64 bit and can fit a u8 value.
-        // FIXME(nagisa): WHAT DOES THIS MEAA~~~AAAN????
-        let stack_size = stack_size / 8;
         if stack_size > 0 {
+            let mut cur_offset = -1;
+            for reg in &frame_layout.clobbered_callee_saves {
+                let rreg = reg.to_reg();
+                let ty = match rreg.class() {
+                    RegClass::Int => I64,
+                    RegClass::Float => F64,
+                    RegClass::Vector => unimplemented!("Vector Clobber Restores"),
+                };
+                insts.push(Self::gen_load_stack(
+                    StackAMode::SPOffset(cur_offset, ty),
+                    Writable::from_reg(real_reg_to_reg(reg.to_reg())),
+                    ty,
+                ));
+                cur_offset -= 1
+            }
             insts.push(Inst::ReleaseSp {
                 amount: stack_size.into(),
             });
-        }
-        let mut cur_offset = 1;
-        for reg in &frame_layout.clobbered_callee_saves {
-            let rreg = reg.to_reg();
-            let ty = match rreg.class() {
-                RegClass::Int => I64,
-                RegClass::Float => F64,
-                RegClass::Vector => unimplemented!("Vector Clobber Restores"),
-            };
-            insts.push(Self::gen_load_stack(
-                StackAMode::SPOffset(-cur_offset, ty),
-                Writable::from_reg(real_reg_to_reg(reg.to_reg())),
-                ty,
-            ));
-            cur_offset += 1
         }
         insts
     }
@@ -650,12 +602,8 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
         MACHINE_ENV.get_or_init(create_reg_environment)
     }
 
-    fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
-        if call_conv_of_callee == isa::CallConv::Tail {
-            TAIL_CLOBBERS
-        } else {
-            DEFAULT_CLOBBERS
-        }
+    fn get_regs_clobbered_by_call(_call_conv_of_callee: isa::CallConv) -> PRegSet {
+        PRegSet::empty()
     }
 
     fn get_ext_mode(
@@ -705,32 +653,19 @@ impl ZkAsmABICallSite {
     }
 }
 
-// TODO(akashin): Figure out the correct clobbering convention.
-const CALLEE_SAVE_X_REG: [bool; 32] = [
-    false, false, false, false, false, false, false, false, // 0-7
-    false, false, false, false, false, false, false, false, // 8-15
-    false, false, false, false, false, false, false, false, // 16-23
-    false, false, false, false, false, false, false, false, // 24-31
-];
-const CALLEE_SAVE_F_REG: [bool; 32] = [
-    false, false, false, false, false, false, false, false, // 0-7
-    true, false, false, false, false, false, false, false, // 8-15
-    false, false, true, true, true, true, true, true, // 16-23
-    true, true, true, true, false, false, false, false, // 24-31
-];
-
 /// This should be the registers that must be saved by callee.
 #[inline]
 fn is_reg_saved_in_prologue(conv: CallConv, reg: RealReg) -> bool {
     if conv == CallConv::Tail {
-        return false;
+        todo!()
     }
-
+    // TODO(akashin): Figure out the correct calling convention.
     match reg.class() {
-        RegClass::Int => CALLEE_SAVE_X_REG[reg.hw_enc() as usize],
-        RegClass::Float => CALLEE_SAVE_F_REG[reg.hw_enc() as usize],
-        // All vector registers are caller saved.
-        RegClass::Vector => false,
+        // FIXME(#45): Register A for returns? Find where in the code is that defined.
+        RegClass::Int if reg.hw_enc() == 10 => false,
+        RegClass::Int => true,
+        RegClass::Float => todo!(),
+        RegClass::Vector => todo!(),
     }
 }
 
@@ -741,227 +676,9 @@ fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
             RegClass::Int => {
                 clobbered_size += 8;
             }
-            RegClass::Float => {
-                clobbered_size += 8;
-            }
-            RegClass::Vector => unimplemented!("Vector Size Clobbered"),
+            RegClass::Float => unimplemented!("floats are not supported"),
+            RegClass::Vector => unimplemented!("vectors are not supported"),
         }
     }
     align_to(clobbered_size, 16)
-}
-
-const fn default_clobbers() -> PRegSet {
-    PRegSet::empty()
-        .with(px_reg(1))
-        .with(px_reg(5))
-        .with(px_reg(6))
-        .with(px_reg(7))
-        .with(px_reg(10))
-        .with(px_reg(11))
-        // CTX register is not clobbered.
-        // .with(px_reg(12))
-        .with(px_reg(13))
-        .with(px_reg(14))
-        .with(px_reg(15))
-        .with(px_reg(16))
-        .with(px_reg(17))
-        .with(px_reg(28))
-        .with(px_reg(29))
-        .with(px_reg(30))
-        .with(px_reg(31))
-    // F Regs
-    // .with(pf_reg(0))
-    // .with(pf_reg(1))
-    // .with(pf_reg(2))
-    // .with(pf_reg(3))
-    // .with(pf_reg(4))
-    // .with(pf_reg(5))
-    // .with(pf_reg(6))
-    // .with(pf_reg(7))
-    // .with(pf_reg(9))
-    // .with(pf_reg(10))
-    // .with(pf_reg(11))
-    // .with(pf_reg(12))
-    // .with(pf_reg(13))
-    // .with(pf_reg(14))
-    // .with(pf_reg(15))
-    // .with(pf_reg(16))
-    // .with(pf_reg(17))
-    // .with(pf_reg(28))
-    // .with(pf_reg(29))
-    // .with(pf_reg(30))
-    // .with(pf_reg(31))
-    // V Regs - All vector regs get clobbered
-    // .with(pv_reg(0))
-    // .with(pv_reg(1))
-    // .with(pv_reg(2))
-    // .with(pv_reg(3))
-    // .with(pv_reg(4))
-    // .with(pv_reg(5))
-    // .with(pv_reg(6))
-    // .with(pv_reg(7))
-    // .with(pv_reg(8))
-    // .with(pv_reg(9))
-    // .with(pv_reg(10))
-    // .with(pv_reg(11))
-    // .with(pv_reg(12))
-    // .with(pv_reg(13))
-    // .with(pv_reg(14))
-    // .with(pv_reg(15))
-    // .with(pv_reg(16))
-    // .with(pv_reg(17))
-    // .with(pv_reg(18))
-    // .with(pv_reg(19))
-    // .with(pv_reg(20))
-    // .with(pv_reg(21))
-    // .with(pv_reg(22))
-    // .with(pv_reg(23))
-    // .with(pv_reg(24))
-    // .with(pv_reg(25))
-    // .with(pv_reg(26))
-    // .with(pv_reg(27))
-    // .with(pv_reg(28))
-    // .with(pv_reg(29))
-    // .with(pv_reg(30))
-    // .with(pv_reg(31))
-}
-
-const DEFAULT_CLOBBERS: PRegSet = default_clobbers();
-
-// All allocatable registers are clobbered by calls using the `tail` calling
-// convention.
-const fn tail_clobbers() -> PRegSet {
-    PRegSet::empty()
-        // `x0` is the zero register, and not allocatable.
-        .with(px_reg(1))
-        // `x2` is the stack pointer, `x3` is the global pointer, and `x4` is
-        // the thread pointer. None are allocatable.
-        .with(px_reg(5))
-        .with(px_reg(6))
-        .with(px_reg(7))
-        // `x8` is the frame pointer, and not allocatable.
-        .with(px_reg(9))
-        .with(px_reg(10))
-        .with(px_reg(10))
-        .with(px_reg(11))
-        .with(px_reg(12))
-        .with(px_reg(13))
-        .with(px_reg(14))
-        .with(px_reg(15))
-        .with(px_reg(16))
-        .with(px_reg(17))
-        .with(px_reg(18))
-        .with(px_reg(19))
-        .with(px_reg(20))
-        .with(px_reg(21))
-        .with(px_reg(22))
-        .with(px_reg(23))
-        .with(px_reg(24))
-        .with(px_reg(25))
-        .with(px_reg(26))
-        .with(px_reg(27))
-        .with(px_reg(28))
-        .with(px_reg(29))
-    // `x30` and `x31` are reserved as scratch registers, and are not
-    // allocatable.
-    //
-    // F Regs
-    // .with(pf_reg(0))
-    // .with(pf_reg(1))
-    // .with(pf_reg(2))
-    // .with(pf_reg(3))
-    // .with(pf_reg(4))
-    // .with(pf_reg(5))
-    // .with(pf_reg(6))
-    // .with(pf_reg(7))
-    // .with(pf_reg(9))
-    // .with(pf_reg(10))
-    // .with(pf_reg(11))
-    // .with(pf_reg(12))
-    // .with(pf_reg(13))
-    // .with(pf_reg(14))
-    // .with(pf_reg(15))
-    // .with(pf_reg(16))
-    // .with(pf_reg(17))
-    // .with(pf_reg(18))
-    // .with(pf_reg(19))
-    // .with(pf_reg(20))
-    // .with(pf_reg(21))
-    // .with(pf_reg(22))
-    // .with(pf_reg(23))
-    // .with(pf_reg(24))
-    // .with(pf_reg(25))
-    // .with(pf_reg(26))
-    // .with(pf_reg(27))
-    // .with(pf_reg(28))
-    // .with(pf_reg(29))
-    // .with(pf_reg(30))
-    // .with(pf_reg(31))
-    // V Regs
-    // .with(pv_reg(0))
-    // .with(pv_reg(1))
-    // .with(pv_reg(2))
-    // .with(pv_reg(3))
-    // .with(pv_reg(4))
-    // .with(pv_reg(5))
-    // .with(pv_reg(6))
-    // .with(pv_reg(7))
-    // .with(pv_reg(8))
-    // .with(pv_reg(9))
-    // .with(pv_reg(10))
-    // .with(pv_reg(11))
-    // .with(pv_reg(12))
-    // .with(pv_reg(13))
-    // .with(pv_reg(14))
-    // .with(pv_reg(15))
-    // .with(pv_reg(16))
-    // .with(pv_reg(17))
-    // .with(pv_reg(18))
-    // .with(pv_reg(19))
-    // .with(pv_reg(20))
-    // .with(pv_reg(21))
-    // .with(pv_reg(22))
-    // .with(pv_reg(23))
-    // .with(pv_reg(24))
-    // .with(pv_reg(25))
-    // .with(pv_reg(26))
-    // .with(pv_reg(27))
-    // .with(pv_reg(28))
-    // .with(pv_reg(29))
-    // .with(pv_reg(30))
-    // .with(pv_reg(31))
-}
-
-const TAIL_CLOBBERS: PRegSet = tail_clobbers();
-
-impl ZkAsmMachineDeps {
-    fn gen_probestack_unroll(insts: &mut SmallInstVec<Inst>, guard_size: u32, probe_count: u32) {
-        insts.reserve(probe_count as usize);
-        for i in 0..probe_count {
-            let offset = (guard_size * (i + 1)) as i64;
-            insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(-offset, I8),
-                zero_reg(),
-                I32,
-            ));
-        }
-    }
-
-    fn gen_probestack_loop(
-        insts: &mut SmallInstVec<Inst>,
-        call_conv: isa::CallConv,
-        guard_size: u32,
-        probe_count: u32,
-    ) {
-        // Must be a caller-saved register that is not an argument.
-        let tmp = match call_conv {
-            isa::CallConv::Tail => Writable::from_reg(x_reg(1)),
-            _ => Writable::from_reg(x_reg(28)), // t3
-        };
-        insts.push(Inst::StackProbeLoop {
-            guard_size,
-            probe_count,
-            tmp,
-        });
-    }
 }

--- a/cranelift/codegen/src/isa/zkasm/inst.isle
+++ b/cranelift/codegen/src/isa/zkasm/inst.isle
@@ -52,7 +52,7 @@
       (args VecArgPair))
 
     (Ret (rets VecRetPair)
-         (stack_bytes_to_pop u32))
+         (stack_bytes_to_pop u64))
 
     (Extend
       (rd WritableReg)
@@ -61,8 +61,11 @@
       (from_bits u8)
       (to_bits u8))
 
-    (AdjustSp
-      (amount i64))
+    ;; Adjust the stack pointer as necessary.
+    (ReserveSp
+      (amount u64))
+    (ReleaseSp
+      (amount u64))
 
     (Call
       (info BoxCallInfo))

--- a/cranelift/codegen/src/isa/zkasm/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit_tests.rs
@@ -32,7 +32,7 @@ fn test_zkasm_binemit() {
             rets: vec![],
             stack_bytes_to_pop: 16,
         },
-        "SP - 16 => SP\n  :JMP(RR)",
+        "SP - 2 => SP\n  :JMP(RR)",
     ));
     // TODO: a test with `rets`.
     insns.push(TestUnit::new(

--- a/cranelift/zkasm_data/generated/add.zkasm
+++ b/cranelift/zkasm_data/generated/add.zkasm
@@ -4,11 +4,15 @@ start:
   :JMP(finalizeExecution)
 function_1:
   SP + 1 => SP
-  RR :MSTORE(SP)
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  B :MSTORE(SP - 1)
   2 + 3 => A
   5 => B
   B :ASSERT
-  $ => RR :MLOAD(SP)
+  $ => B :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)
 finalizeExecution:

--- a/cranelift/zkasm_data/generated/add_func.zkasm
+++ b/cranelift/zkasm_data/generated/add_func.zkasm
@@ -4,14 +4,18 @@ start:
   :JMP(finalizeExecution)
 function_1:
   SP + 1 => SP
-  RR :MSTORE(SP)
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  B :MSTORE(SP - 1)
   2 => A
   3 => B
   zkPC + 2 => RR
   :JMP(function_2)
   5 => B
   B :ASSERT
-  $ => RR :MLOAD(SP)
+  $ => B :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)
 function_2:

--- a/cranelift/zkasm_data/generated/counter.zkasm
+++ b/cranelift/zkasm_data/generated/counter.zkasm
@@ -4,7 +4,9 @@ start:
   :JMP(finalizeExecution)
 function_1:
   SP + 1 => SP
-  RR :MSTORE(SP)
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  B :MSTORE(SP - 1)
   0 => A
   :JMP(L1_1)
 L1_1:
@@ -17,7 +19,9 @@ L1_1:
 L1_3:
   10 => B
   B :ASSERT
-  $ => RR :MLOAD(SP)
+  $ => B :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)
 finalizeExecution:

--- a/cranelift/zkasm_data/generated/fibonacci.zkasm
+++ b/cranelift/zkasm_data/generated/fibonacci.zkasm
@@ -5,7 +5,7 @@ start:
 function_1:
   SP + 1 => SP
   RR :MSTORE(SP)
-  SP + 1 => SP
+  SP + 0 => SP
   0 => A
   A => D
   0 => A
@@ -30,7 +30,7 @@ L1_3:
   89 => B
   C => A
   B :ASSERT
-  SP - 1 => SP
+  SP - 0 => SP
   $ => RR :MLOAD(SP)
   SP - 1 => SP
   :JMP(RR)

--- a/cranelift/zkasm_data/generated/fibonacci.zkasm
+++ b/cranelift/zkasm_data/generated/fibonacci.zkasm
@@ -4,8 +4,12 @@ start:
   :JMP(finalizeExecution)
 function_1:
   SP + 1 => SP
-  RR :MSTORE(SP)
-  SP + 0 => SP
+  RR :MSTORE(SP - 1)
+  SP + 5 => SP
+  C :MSTORE(SP - 1)
+  D :MSTORE(SP - 2)
+  E :MSTORE(SP - 3)
+  B :MSTORE(SP - 4)
   0 => A
   A => D
   0 => A
@@ -30,8 +34,12 @@ L1_3:
   89 => B
   C => A
   B :ASSERT
-  SP - 0 => SP
-  $ => RR :MLOAD(SP)
+  $ => C :MLOAD(SP - 1)
+  $ => D :MLOAD(SP - 2)
+  $ => E :MLOAD(SP - 3)
+  $ => B :MLOAD(SP - 4)
+  SP - 5 => SP
+  $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)
 finalizeExecution:

--- a/cranelift/zkasm_data/generated/locals.zkasm
+++ b/cranelift/zkasm_data/generated/locals.zkasm
@@ -4,11 +4,15 @@ start:
   :JMP(finalizeExecution)
 function_1:
   SP + 1 => SP
-  RR :MSTORE(SP)
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  B :MSTORE(SP - 1)
   2 + 3 => A
   5 => B
   B :ASSERT
-  $ => RR :MLOAD(SP)
+  $ => B :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)
 finalizeExecution:

--- a/cranelift/zkasm_data/generated/locals_simple.zkasm
+++ b/cranelift/zkasm_data/generated/locals_simple.zkasm
@@ -4,11 +4,15 @@ start:
   :JMP(finalizeExecution)
 function_1:
   SP + 1 => SP
-  RR :MSTORE(SP)
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  B :MSTORE(SP - 1)
   2 => A
   2 => B
   B :ASSERT
-  $ => RR :MLOAD(SP)
+  $ => B :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)
 finalizeExecution:


### PR DESCRIPTION
Best reviewd commit-by-commit. The previous failures turned out to be due to extra `stack_size = stack_size / 8` computation in the prologue/epilogue generation. I however took an opportunity to fix up the register clobbering code in general. In particular, I took a conservative approach of specifying all registers other than A as callee-saved in order to ensure we don’t rely on accidental behaviours this enables. For A I filed https://github.com/near/wasmtime/issues/45 instead, as doing otherwise makes our tests break for the time being.

You will also notice that I fixed the computation of the stack offsets: our stack pointer goes upwards, so once we reserve some space (`SP + 1 => SP`) we must access slots *below* that reserved space, so the first slot we can write to is actually at `SP - 1 .. SP`, not `SP .. SP + 1`.

Fixes #42