### PR TITLE
zkasm: stack alignment is 8 bytes

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/abi.rs
+++ b/cranelift/codegen/src/isa/zkasm/abi.rs
@@ -53,7 +53,7 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
 
     /// Return required stack alignment in bytes.
     fn stack_align(_call_conv: isa::CallConv) -> u32 {
-        1
+        8
     }
 
     fn compute_arg_locs<'a, I>(


### PR DESCRIPTION
Given that stack opeerates in numbers of aligned slots, rather then bytes, making sure that the stack is aligned to 8 bytes can’t be more wrong than aligning it to 1.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
