### PR TITLE
filetest: allow filetests to work for targets without disassembler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ name = "cranelift-filetests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "capstone",
  "cranelift",
  "cranelift-codegen",
  "cranelift-control",

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -760,7 +760,7 @@ impl Inst {
                 format!("##fixed 4-size nop")
             }
             &Inst::Label { imm } => {
-                format!("##label=L{imm}")
+                format!("")
             }
             &Inst::StackProbeLoop {
                 guard_size,

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 
 [dependencies]
 # TODO(nearcore/#9569): Add "zkasm" feature to top-level crate.
+capstone.workspace = true
 cranelift-codegen = { workspace = true, features = ["disas", "zkasm"] }
 cranelift-frontend = { workspace = true }
 cranelift-interpreter = { workspace = true }

--- a/cranelift/filetests/filetests/isa/zkasm/add.clif
+++ b/cranelift/filetests/filetests/isa/zkasm/add.clif
@@ -1,0 +1,38 @@
+test compile precise-output
+target sparc-unknown-unknown
+
+function u0:1(i32 vmctx) fast {
+    sig0 = (i32, i32, i32 vmctx) fast
+    fn0 = u0:0 sig0
+
+    block0(v0: i32):
+        v1 = iconst.i32 0x3b9a_c9ff
+        v2 = iconst.i32 0x3b9a_ca00
+        v3 = iadd v1, v2
+        v4 = iconst.i32 0x7735_93ff
+        call fn0(v3, v4, v0)
+        jump block1
+
+    block1:
+        return
+}
+
+; VCode:
+;     SP + 1 => SP
+;   sd RR,-1(sp)
+;     SP + 2 => SP
+;   sd B,-1(sp)
+; block0:
+;   
+;   +999999999 + +1000000000 => A;
+;   auipc B,0; ld B,12(B); j 12; .8byte 0x773593ff
+;   call userextname0
+;   j label1
+; block1:
+;   
+;   ld B,-1(sp)
+;     SP - 2 => SP
+;   ld RR,-1(sp)
+;     SP - 1 => SP
+;     :JMP(RR)
+


### PR DESCRIPTION
This changeset begins the process of dropping the ad-hoc test framework we had built for ourselves and instead adding the necessary support for zkasm needs into the filetest framework that cranelift had in the first place.

Among other things this will eventually allow us to use `clif-tool` to easily run ad-hoc test cases and integrate alright with the rest of the tooling as well.