### PR TITLE
Unreachable + nop

### DIFF
--- a/ci/test-zk.sh
+++ b/ci/test-zk.sh
@@ -46,8 +46,38 @@ else
     cd ../zkevm-rom
 fi
 
-if [ "$ALL_FILES" = true ]; then
-    node tools/run-tests-zkasm.js $BASE_DIR/cranelift/zkasm_data/generated
-else
+if [ "$ALL_FILES" = false ]; then
     node tools/run-tests-zkasm.js "$BASE_DIR/$1"
+    exit 0
+fi
+
+FAIL_PREFIX="_should_fail_"
+all_passed=true
+
+for file in "$BASE_DIR/cranelift/zkasm_data/generated"/*; do
+  filename=$(basename -- "$file")
+  
+  if [[ $filename == $FAIL_PREFIX* ]]; then
+    # If the file name starts with "_should_fail_", we should expect a non-zero exit code
+    node tools/run-tests-zkasm.js "$file" > /dev/null 2>&1 || exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+      echo -e "\033[0;32m    --> fail\033[0m $BASE_DIR/cranelift/zkasm_data/generated/$filename"
+    else
+      echo -e "\033[0;31m    --> pass\033[0m $BASE_DIR/cranelift/zkasm_data/generated/$filename"
+      echo "    --> fail $filename"
+      all_passed=false
+    fi
+  else
+    # For all other files, just run the node command and show the output
+    if ! node tools/run-tests-zkasm.js "$file"; then
+      all_passed=false
+    fi
+  fi
+done
+
+# Exit with 0 if all tests passed, 1 otherwise
+if $all_passed; then
+  exit 0
+else
+  exit 1
 fi

--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -1458,11 +1458,7 @@ impl MachInstEmit for Inst {
                         sink.bind_label(label_jump_over, &mut state.ctrl_plane); */
             }
             &Inst::Udf { trap_code } => {
-                todo!() /* sink.add_trap(trap_code);
-                        if let Some(s) = state.take_stack_map() {
-                            sink.add_stack_map(StackMapExtent::UpcomingBytes(4), s);
-                        }
-                        sink.put_data(Inst::TRAP_OPCODE); */
+                put_string(&format!("UNREACHABLE: {}\n", trap_code), sink);
             }
 
             &Inst::Popcnt {

--- a/cranelift/filetests/src/test_zkasm.rs
+++ b/cranelift/filetests/src/test_zkasm.rs
@@ -205,5 +205,7 @@ mod tests {
         or,
         div,
         i64_div,
+        nop,
+        _should_fail_unreachable,
     }
 }

--- a/cranelift/zkasm_data/_should_fail_unreachable.wat
+++ b/cranelift/zkasm_data/_should_fail_unreachable.wat
@@ -1,0 +1,6 @@
+(module
+ (import "env" "assert_eq" (func $assert_eq (param i32) (param i32)))
+ (func $main
+	unreachable
+	call $assert_eq)
+ (start $main))

--- a/cranelift/zkasm_data/generated/_should_fail_unreachable.zkasm
+++ b/cranelift/zkasm_data/generated/_should_fail_unreachable.zkasm
@@ -1,0 +1,9 @@
+start:
+  zkPC + 2 => RR
+  :JMP(function_1)
+  :JMP(finalizeExecution)
+function_1:
+  UNREACHABLE: unreachable
+finalizeExecution:
+  ${beforeLast()}  :JMPN(finalizeExecution)
+                   :JMP(start)

--- a/cranelift/zkasm_data/generated/nop.zkasm
+++ b/cranelift/zkasm_data/generated/nop.zkasm
@@ -1,0 +1,20 @@
+start:
+  zkPC + 2 => RR
+  :JMP(function_1)
+  :JMP(finalizeExecution)
+function_1:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  B :MSTORE(SP - 1)
+  0 => A
+  0 => B
+  B :ASSERT
+  $ => B :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+finalizeExecution:
+  ${beforeLast()}  :JMPN(finalizeExecution)
+                   :JMP(start)

--- a/cranelift/zkasm_data/nop.wat
+++ b/cranelift/zkasm_data/nop.wat
@@ -1,0 +1,10 @@
+(module
+ (import "env" "assert_eq" (func $assert_eq (param i32) (param i32)))
+ (func $main
+	i32.const 0
+	nop
+    nop
+    nop
+	i32.const 0
+	call $assert_eq)
+ (start $main))


### PR DESCRIPTION
Unreachable + test for nop + testing of files that should fail in CI. I didn't find any opcode in zkasm which perform analogue of ``unreachable`` in wasm, so just write UNREACHABLE in zkasm code, interpreter of zkasm clearly shows that error is in this line.
