### PR TITLE
zkasm: crude implementation of ineg

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst.isle
+++ b/cranelift/codegen/src/isa/zkasm/inst.isle
@@ -51,6 +51,10 @@
       (rs1 Reg)
       (rs2 Reg))
 
+    (Ineg
+      (rd WritableReg)
+      (rs1 Reg))
+
     ;; An load
     (Load
       (rd WritableReg)
@@ -566,12 +570,6 @@
 (rule (rv_sub rs1 rs2)
   (alu_rrr (AluOPRRR.Sub) rs1 rs2))
 
-;; Helper for emitting the `neg` instruction.
-;; This instruction is a mnemonic for `sub rd, zero, rs1`.
-(decl rv_neg (XReg) XReg)
-(rule (rv_neg rs1)
-  (alu_rrr (AluOPRRR.Sub) (zero_reg) rs1))
-
 ;; Helper for emitting the `sll` ("Shift Left Logical") instruction.
 ;; rd ← rs1 << rs2
 (decl rv_sll (XReg XReg) XReg)
@@ -601,12 +599,6 @@
 (decl rv_xor (XReg XReg) XReg)
 (rule (rv_xor rs1 rs2)
   (alu_rrr (AluOPRRR.Xor) rs1 rs2))
-
-;; Helper for emitting the `not` instruction.
-;; This instruction is a mnemonic for `xori rd, rs1, -1`.
-; (decl rv_not (XReg) XReg)
-; (rule (rv_not rs1)
-;   (rv_xori rs1 (imm12_const -1)))
 
 ;; Helper for emitting the `and` instruction.
 ;; rd ← rs1 ∧ rs2
@@ -1394,16 +1386,6 @@
 ;; Args are: src, src_ty, dst_ty
 (decl gen_bitcast (Reg Type Type) Reg)
 (rule (gen_bitcast r _ _) r)
-
-;; Negates x
-;; Equivalent to 0 - x
-(decl neg (Type ValueRegs) ValueRegs)
-(rule 1 (neg (fits_in_64 (ty_int ty)) val)
-  (value_reg
-    (rv_neg (value_regs_get val 0))))
-
-(rule 2 (neg $I128 val)
-  (i128_sub (value_regs_zero) val))
 
 ;; Selects the greatest of two registers as signed values.
 (decl max (Type XReg XReg) XReg)

--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -455,6 +455,13 @@ impl MachInstEmit for Inst {
                     sink,
                 );
             }
+            Inst::Ineg { rd, rs1 } => {
+                let rs = allocs.next(*rs1);
+                let rd = allocs.next(rd.to_reg());
+                // TODO(nagisa): this wants to conditionally use the `SUB` instruction instead (if
+                // the negation is for 64 bits)
+                put_string(&format!("0 - {} => {}\n", reg_name(rs), reg_name(rd)), sink);
+            }
             &Inst::MulArith { rd, rs1, rs2 } => {
                 let rs1 = allocs.next(rs1);
                 let rs2 = allocs.next(rs2);

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -518,6 +518,10 @@ fn zkasm_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
         Inst::AddImm32 { rd, src1, src2 } => {
             collector.reg_def(*rd);
         }
+        Inst::Ineg { rd, rs1 } => {
+            collector.reg_use(*rs1);
+            collector.reg_def(*rd);
+        }
     }
 }
 
@@ -1014,7 +1018,12 @@ impl Inst {
                 let rd = format_reg(rd.to_reg(), allocs);
                 format!("{src1} + {src2} => {rd};")
             }
-
+            Inst::Ineg { rd, rs1 } => {
+                let rd = format_reg(rd.to_reg(), allocs);
+                let rs = format_reg(*rs1, allocs);
+                // FIXME: should this use a SUB?
+                format!("0 - {rs} => {rd}")
+            }
             &Inst::Load {
                 rd,
                 op,

--- a/cranelift/codegen/src/isa/zkasm/lower.isle
+++ b/cranelift/codegen/src/isa/zkasm/lower.isle
@@ -59,8 +59,11 @@
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type (ty_int ty) (ineg val)))
-  (neg ty val))
+(rule (lower (ineg val))
+  (let
+    ((result WritableXReg (temp_writable_xreg))
+      (_ Unit (emit (MInst.Ineg result (value_regs_get val 0)))))
+    (output_xreg result)))
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
No test here as there isn’t really a wasm instruction that directly becomes `ineg`, except perhaps through optimizations. Best way to test this would be to have clift test instead, but we don’t have infrastructure for those targetting zkasm either.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
