### PR TITLE
Remove all code pertinent to 128-bit integers

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst.isle
+++ b/cranelift/codegen/src/isa/zkasm/inst.isle
@@ -906,11 +906,6 @@
 
 
 (decl gen_and (Type ValueRegs ValueRegs) ValueRegs)
-(rule 1 (gen_and $I128 x y)
-  (value_regs
-    (rv_and (value_regs_get x 0) (value_regs_get y 0))
-    (rv_and (value_regs_get x 1) (value_regs_get y 1))))
-
 (rule 0 (gen_and (fits_in_64 _) x y)
   (rv_and (value_regs_get x 0) (value_regs_get y 0)))
 
@@ -921,11 +916,6 @@
 
 
 (decl gen_or (Type ValueRegs ValueRegs) ValueRegs)
-(rule 1 (gen_or $I128 x y)
-  (value_regs
-    (rv_or (value_regs_get x 0) (value_regs_get y 0))
-    (rv_or (value_regs_get x 1) (value_regs_get y 1))))
-
 (rule 0 (gen_or (fits_in_64 _) x y)
   (rv_or (value_regs_get x 0) (value_regs_get y 0)))
 
@@ -955,37 +945,9 @@
 (rule (lower_ctz ty x)
   (gen_cltz $false x ty))
 
-;; Count trailing zeros from a i128 bit value.
-;; We count both halves separately and conditionally add them if it makes sense.
-(decl lower_ctz_128 (ValueRegs) ValueRegs)
-(rule (lower_ctz_128 x)
-  (let ((x_lo XReg (value_regs_get x 0))
-        (x_hi XReg (value_regs_get x 1))
-        ;; Count both halves
-        (high XReg (lower_ctz $I64 x_hi))
-        (low XReg (lower_ctz $I64 x_lo))
-        ;; Only add the top half if the bottom is zero
-        (high XReg (gen_select_reg (IntCC.Equal) x_lo (zero_reg) high (zero_reg)))
-        (result XReg (rv_add low high)))
-    (extend result (ExtendOp.Zero) $I64 $I128)))
-
 (decl lower_clz (Type XReg) XReg)
 (rule (lower_clz ty rs)
   (gen_cltz $true rs ty))
-
-;; Count leading zeros from a i128 bit value.
-;; We count both halves separately and conditionally add them if it makes sense.
-(decl lower_clz_i128 (ValueRegs) ValueRegs)
-(rule (lower_clz_i128 x)
-  (let ((x_lo XReg (value_regs_get x 0))
-        (x_hi XReg (value_regs_get x 1))
-        ;; Count both halves
-        (high XReg (lower_clz $I64 x_hi))
-        (low XReg (lower_clz $I64 x_lo))
-        ;; Only add the bottom zeros if the top half is zero
-        (low XReg (gen_select_reg (IntCC.Equal) x_hi (zero_reg) low (zero_reg)))
-        (result XReg (rv_add high low)))
-    (extend result (ExtendOp.Zero) $I64 $I128)))
 
 (decl gen_cltz (bool XReg Type) XReg)
 (rule (gen_cltz leading rs ty)
@@ -1005,7 +967,6 @@
   (extend val (ExtendOp.Zero) ty $I64))
 ;; If the value is larger than one machine register, we don't need to do anything
 (rule 1 (ext_int_if_need _ r $I64) r)
-(rule 2 (ext_int_if_need _ r $I128) r)
 
 
 ;; Performs a zero extension of the given value
@@ -1175,64 +1136,6 @@
       (sum WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Popcnt sum step tmp rs ty))))
     (writable_reg_to_reg sum)))
-
-; (decl lower_i128_rotl (ValueRegs ValueRegs) ValueRegs)
-; (rule
-;   (lower_i128_rotl x y)
-;   (let
-;     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-;       (shamt XReg (value_regs_get tmp 0))
-;       (len_sub_shamt XReg (value_regs_get tmp 1))
-;       ;;
-;       (low_part1 XReg (rv_sll (value_regs_get x 0) shamt))
-;       (low_part2 XReg (rv_srl (value_regs_get x 1) len_sub_shamt))
-;       ;;; if shamt == 0 low_part2 will overflow we should zero instead.
-;       (low_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part2))
-;       (low XReg (rv_or low_part1 low_part3))
-;       ;;
-;       (high_part1 XReg (rv_sll (value_regs_get x 1) shamt))
-;       (high_part2 XReg (rv_srl (value_regs_get x 0) len_sub_shamt))
-;       (high_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
-;       (high XReg (rv_or high_part1 high_part3))
-;       ;;
-;       (const64 XReg (load_u64_constant 64))
-;       (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
-;     ;; right now we only rotate less than 64 bits.
-;     ;; if shamt is greater than or equal 64 , we should switch low and high.
-;     (value_regs
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 low high)
-;     )))
-
-
-; (decl lower_i128_rotr (ValueRegs ValueRegs) ValueRegs)
-; (rule
-;   (lower_i128_rotr x y)
-;   (let
-;     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-;       (shamt XReg (value_regs_get tmp 0))
-;       (len_sub_shamt XReg (value_regs_get tmp 1))
-;       ;;
-;       (low_part1 XReg (rv_srl (value_regs_get x 0) shamt))
-;       (low_part2 XReg (rv_sll (value_regs_get x 1) len_sub_shamt))
-;       ;;; if shamt == 0 low_part2 will overflow we should zero instead.
-;       (low_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part2))
-;       (low XReg (rv_or low_part1 low_part3))
-;       ;;
-;       (high_part1 XReg (rv_srl (value_regs_get x 1) shamt))
-;       (high_part2 XReg (rv_sll (value_regs_get x 0) len_sub_shamt))
-;       (high_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
-;       (high XReg (rv_or high_part1 high_part3))
-;
-;       ;;
-;       (const64 XReg (load_u64_constant 64))
-;       (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
-;     ;; right now we only rotate less than 64 bits.
-;     ;; if shamt is greater than or equal 64 , we should switch low and high.
-;     (value_regs
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 low high)
-;     )))
 
 (decl gen_amode (Reg Offset32 Type) AMode)
 (extern constructor gen_amode gen_amode)
@@ -1450,7 +1353,6 @@
       (extend r op ity $I64))
 
 (rule (normalize_cmp_value $I64  r _) r)
-(rule (normalize_cmp_value $I128 r _) r)
 
 (decl normalize_fcvt_from_int (XReg Type ExtendOp) XReg)
 (rule 2 (normalize_fcvt_from_int r (fits_in_16 ty) op)
@@ -1464,22 +1366,12 @@
 (decl truthy_to_reg (Type ValueRegs) XReg)
 (rule 1 (truthy_to_reg (fits_in_64 _) regs)
       (value_regs_get regs 0))
-(rule 0 (truthy_to_reg $I128 regs)
-      (let ((lo XReg (value_regs_get regs 0))
-            (hi XReg (value_regs_get regs 1)))
-        (rv_or lo hi)))
 
 ;; Default behavior for branching based on an input value.
 (rule
   (lower_branch (brif v @ (value_type ty) _ _) targets)
   (lower_cond_br (IntCC.NotEqual) (normalize_cmp_value ty v (ExtendOp.Zero)) targets ty))
 
-;; Special case for SI128 to reify the comparison value and branch on it.
-(rule 2
-  (lower_branch (brif v @ (value_type $I128) _ _) targets)
-  (let ((zero ValueRegs (value_regs (zero_reg) (zero_reg)))
-        (cmp XReg (gen_icmp (IntCC.NotEqual) v zero $I128)))
-    (lower_cond_br (IntCC.NotEqual) cmp targets $I64)))
 
 ;; Branching on the result of an icmp
 (rule 1

--- a/cranelift/codegen/src/isa/zkasm/lower.isle
+++ b/cranelift/codegen/src/isa/zkasm/lower.isle
@@ -57,9 +57,6 @@
 (rule 1 (lower (has_type (fits_in_32 (ty_int ty)) (isub x y)))
   (rv_subw x y))
 
-(rule 2 (lower (has_type $I128 (isub x y)))
-  (i128_sub x y))
-
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (ty_int ty) (ineg val)))
@@ -72,33 +69,6 @@
 
 (rule 1 (lower (has_type (fits_in_32 (ty_int ty)) (imul x y)))
   (zk_mul x y))
-
-;; for I128
-(rule 2 (lower (has_type $I128 (imul x y)))
-  (let
-    ((x_regs ValueRegs x)
-      (x_lo XReg (value_regs_get x_regs 0))
-      (x_hi XReg (value_regs_get x_regs 1))
-
-      ;; Get the high/low registers for `y`.
-      (y_regs ValueRegs y)
-      (y_lo XReg (value_regs_get y_regs 0))
-      (y_hi XReg (value_regs_get y_regs 1))
-
-      ;; 128bit mul formula:
-      ;;   dst_lo = x_lo * y_lo
-      ;;   dst_hi = mulhu(x_lo, y_lo) + (x_lo * y_hi) + (x_hi * y_lo)
-      ;;
-      ;; We can convert the above formula into the following
-      ;; mulhu   dst_hi, x_lo, y_lo
-      ;; madd    dst_hi, x_lo, y_hi, dst_hi
-      ;; madd    dst_hi, x_hi, y_lo, dst_hi
-      ;; madd    dst_lo, x_lo, y_lo, zero
-      (dst_hi1 XReg (rv_mulhu x_lo y_lo))
-      (dst_hi2 XReg (madd x_lo y_hi dst_hi1))
-      (dst_hi XReg (madd x_hi y_lo dst_hi2))
-      (dst_lo XReg (madd x_lo y_lo (zero_reg))))
-    (value_regs dst_lo dst_hi)))
 
 ;;;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_int_ref_scalar_64 ty) (smulhi x y)))
@@ -152,34 +122,19 @@
 (rule 0 (lower (has_type (fits_in_64 (ty_int ty)) (bxor x y)))
   (rv_xor x y))
 
-(rule 3 (lower (has_type $I128 (bxor x y)))
-  (lower_b128_binary (AluOPRRR.Xor) x y))
-
 ;;;; Rules for `bit_reverse` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;; Rules for `bswap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 1 (lower (has_type (fits_in_64 (ty_int ty)) (bswap x)))
   (gen_bswap ty x))
 
-(rule 2 (lower (has_type $I128 (bswap x)))
-  (value_regs
-    (gen_bswap $I64 (value_regs_get x 1))
-    (gen_bswap $I64 (value_regs_get x 0))))
-
-
 ;;;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (ctz x)))
   (lower_ctz ty x))
 
-(rule 1 (lower (has_type $I128 (ctz x)))
-  (lower_ctz_128 x))
-
 ;;;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (clz x)))
   (lower_clz ty x))
-
-(rule 1 (lower (has_type $I128 (clz x)))
-  (lower_clz_i128 x))
 
 ;;;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type out_ty (uextend val @ (value_type in_ty))))
@@ -223,26 +178,6 @@
 (rule 1 (lower (has_type $I64 (ishl x y)))
   (rv_sll x (value_regs_get y 0)))
 
-; ;; I128 cases
-; (rule 4 (lower (has_type $I128 (ishl x y)))
-;   (let ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-;         (shamt XReg (value_regs_get tmp 0))
-;         (len_sub_shamt XReg (value_regs_get tmp 1))
-;         ;;
-;         (low XReg (rv_sll (value_regs_get x 0) shamt))
-;         ;; high part.
-;         (high_part1 XReg (rv_srl (value_regs_get x 0) len_sub_shamt))
-;         (high_part2 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part1))
-;         ;;
-;         (high_part3 XReg (rv_sll (value_regs_get x 1) shamt))
-;         (high XReg (rv_or high_part2 high_part3))
-;         ;;
-;         (const64 XReg (load_u64_constant 64))
-;         (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
-;     (value_regs
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 (zero_reg) low)
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 low high))))
-
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; 8/16 bit types need a mask on the shift amount, and the LHS needs to be
@@ -258,25 +193,6 @@
 ;; Similarly, the 64bit version does the right thing.
 (rule 1 (lower (has_type $I64 (ushr x y)))
   (rv_srl x (value_regs_get y 0)))
-
-; (rule 3 (lower (has_type $I128 (ushr x y)))
-;   (let ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-;         (shamt XReg (value_regs_get tmp 0))
-;         (len_sub_shamt XReg (value_regs_get tmp 1))
-;         ;; low part.
-;         (low_part1 XReg (rv_sll (value_regs_get x 1) len_sub_shamt))
-;         (low_part2 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part1))
-;         ;;
-;         (low_part3 XReg (rv_srl (value_regs_get x 0) shamt))
-;         (low XReg (rv_or low_part2 low_part3))
-;         ;;
-;         (const64 XReg (load_u64_constant 64))
-;         ;;
-;         (high XReg (rv_srl (value_regs_get x 1) shamt))
-;         (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
-;     (value_regs
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 (zero_reg) high))))
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -294,43 +210,13 @@
 (rule 1 (lower (has_type $I64 (sshr x y)))
   (rv_sra x (value_regs_get y 0)))
 
-; (rule 3 (lower (has_type $I128 (sshr x y)))
-;   (let ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-;         (shamt XReg (value_regs_get tmp 0))
-;         (len_sub_shamt XReg (value_regs_get tmp 1))
-;         ;; low part.
-;         (low_part1 XReg (rv_sll (value_regs_get x 1) len_sub_shamt))
-;         (low_part2 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part1))
-;         ;;
-;         (low_part3 XReg (rv_srl (value_regs_get x 0) shamt))
-;         (low XReg (rv_or low_part2 low_part3))
-;         ;;
-;         (const64 XReg (load_u64_constant 64))
-;         ;;
-;         (high XReg (rv_sra (value_regs_get x 1) shamt))
-;         ;;
-;         (const_neg_1 XReg (load_imm12 -1))
-;         ;;
-;         (high_replacement XReg (gen_select_reg (IntCC.SignedLessThan) (value_regs_get x 1) (zero_reg) const_neg_1 (zero_reg)))
-;         (const64 XReg (load_u64_constant 64))
-;         (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
-;     (value_regs
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)
-;       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high_replacement high))))
-
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (rotl x y)))
   (lower_rotl ty (zext x ty $I64) (value_regs_get y 0)))
 
-; (rule 1 (lower (has_type $I128 (rotl x y)))
-;   (lower_i128_rotl x y))
-
 ;;;; Rules for `rotr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (rotr x y)))
   (lower_rotr ty (zext x ty $I64) (value_regs_get y 0)))
-
-; (rule 1 (lower (has_type $I128 (rotr x y)))
-;   (lower_i128_rotr x y))
 
 ;;;;;  Rules for `ireduce`;;;;;;;;;;;;;;;;;
 (rule
@@ -381,15 +267,6 @@
     ((t1 XReg (value_regs_get x 0))
       (t2 XReg (value_regs_get x 1)))
     (output_pair t1 t2)))
-
-;;;;;  Rules for `iconcat`;;;;;;;;;
-(rule
-  (lower (has_type $I128 (iconcat x y)))
-  (let
-    ((t1 XReg x)
-      (t2 XReg y))
-    (value_regs t1 t2)))
-
 
 ;;;;;  Rules for `smax`;;;;;;;;;
 
@@ -458,10 +335,6 @@
   (lower (has_type ty (load flags p @ (value_type (ty_addr32 _)) offset)))
   (gen_load p offset (load_op ty) flags ty)
 )
-;;;; for I128
-(rule 1
-  (lower (has_type $I128 (load flags p @ (value_type (ty_addr64 _)) offset)))
-  (gen_load_128 p offset flags))
 
 ;;;;;  Rules for `istore8`;;;;;;;;;
 (rule
@@ -481,11 +354,6 @@
 (rule
   (lower (store flags x @ (value_type ty) p @ (value_type (ty_addr32 _)) offset))
   (gen_store p offset (store_op ty) flags x))
-
-;;; special for I128
-(rule 1
-  (lower (store flags x @ (value_type $I128 ) p @ (value_type (ty_addr64 _)) offset))
-  (gen_store_128 p offset flags x))
 
 (decl gen_icmp (IntCC ValueRegs ValueRegs Type) XReg)
 (rule


### PR DESCRIPTION
We won’t have any in our wasm MVP to the best of my knowledge and intuition.

NB: review the last commit only, as this is based on top of another PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
