### PR TITLE
zkasm/ci: Fix set -eux typo

### DIFF
--- a/ci/test-zk-64.sh
+++ b/ci/test-zk-64.sh
@@ -6,7 +6,7 @@
 # in same directory as wasmtime.
 
 set -o pipefail
-set -eox
+set -eux
 
 # Flags and default modes
 PREINSTALLED=true
@@ -63,7 +63,7 @@ for file in "$BASE_DIR/cranelift/zkasm_data/generated"/*; do
   # it seems like zkasmtest sets 1 if smth goes wrong but don't set 0
   # if everything is OK
   exit_code=0
-  
+
   if [[ $filename == $FAIL_PREFIX* ]]; then
     # If the file name starts with "_should_fail_", we should expect a non-zero exit code
     $NODE_CMD "$file" > /dev/null 2>&1 || exit_code=$?


### PR DESCRIPTION
Otherwise bash just prints current settings and fails to set both `-x` and `-e`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
