### PR TITLE
zkasm: implement lowering for bnot

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst.isle
+++ b/cranelift/codegen/src/isa/zkasm/inst.isle
@@ -55,6 +55,10 @@
       (rd WritableReg)
       (rs1 Reg))
 
+    (Bnot
+      (rd WritableReg)
+      (rs1 Reg))
+
     ;; An load
     (Load
       (rd WritableReg)

--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -458,8 +458,7 @@ impl MachInstEmit for Inst {
             Inst::Ineg { rd, rs1 } => {
                 let rs = allocs.next(*rs1);
                 let rd = allocs.next(rd.to_reg());
-                // TODO(nagisa): this wants to conditionally use the `SUB` instruction instead (if
-                // the negation is for 64 bits)
+                // FIXME(#81): should this use a SUB?
                 put_string(
                     &format!("0n - {} => {}\n", reg_name(rs), reg_name(rd)),
                     sink,
@@ -468,12 +467,9 @@ impl MachInstEmit for Inst {
             Inst::Bnot { rd, rs1 } => {
                 let rs = allocs.next(*rs1);
                 let rd = allocs.next(rd.to_reg());
+                // FIXME(#81): should this use a SUB?
                 put_string(
-                    &format!(
-                        "18446744073709551615n - {} => {}\n",
-                        reg_name(rs),
-                        reg_name(rd)
-                    ),
+                    &format!("{}n - {} => {}\n", u64::MAX, reg_name(rs), reg_name(rd)),
                     sink,
                 );
             }

--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -460,7 +460,22 @@ impl MachInstEmit for Inst {
                 let rd = allocs.next(rd.to_reg());
                 // TODO(nagisa): this wants to conditionally use the `SUB` instruction instead (if
                 // the negation is for 64 bits)
-                put_string(&format!("0 - {} => {}\n", reg_name(rs), reg_name(rd)), sink);
+                put_string(
+                    &format!("0n - {} => {}\n", reg_name(rs), reg_name(rd)),
+                    sink,
+                );
+            }
+            Inst::Bnot { rd, rs1 } => {
+                let rs = allocs.next(*rs1);
+                let rd = allocs.next(rd.to_reg());
+                put_string(
+                    &format!(
+                        "18446744073709551615n - {} => {}\n",
+                        reg_name(rs),
+                        reg_name(rd)
+                    ),
+                    sink,
+                );
             }
             &Inst::MulArith { rd, rs1, rs2 } => {
                 let rs1 = allocs.next(rs1);

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -1025,14 +1025,14 @@ impl Inst {
             Inst::Ineg { rd, rs1 } => {
                 let rd = format_reg(rd.to_reg(), allocs);
                 let rs = format_reg(*rs1, allocs);
-                // FIXME: should this use a SUB?
+                // FIXME(#81): should this use a SUB?
                 format!("0n - {rs} => {rd}")
             }
             Inst::Bnot { rd, rs1 } => {
                 let rd = format_reg(rd.to_reg(), allocs);
                 let rs = format_reg(*rs1, allocs);
-                // FIXME: should this use a SUB?
-                format!("18446744073709551615n - {rs} => {rd}")
+                // FIXME(#81): should this use a SUB?
+                format!("{}n - {rs} => {rd}", u64::MAX)
             }
             &Inst::Load {
                 rd,

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -522,6 +522,10 @@ fn zkasm_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
             collector.reg_use(*rs1);
             collector.reg_def(*rd);
         }
+        Inst::Bnot { rd, rs1 } => {
+            collector.reg_use(*rs1);
+            collector.reg_def(*rd);
+        }
     }
 }
 
@@ -1022,7 +1026,13 @@ impl Inst {
                 let rd = format_reg(rd.to_reg(), allocs);
                 let rs = format_reg(*rs1, allocs);
                 // FIXME: should this use a SUB?
-                format!("0 - {rs} => {rd}")
+                format!("0n - {rs} => {rd}")
+            }
+            Inst::Bnot { rd, rs1 } => {
+                let rd = format_reg(rd.to_reg(), allocs);
+                let rs = format_reg(*rs1, allocs);
+                // FIXME: should this use a SUB?
+                format!("18446744073709551615n - {rs} => {rd}")
             }
             &Inst::Load {
                 rd,

--- a/cranelift/codegen/src/isa/zkasm/lower.isle
+++ b/cranelift/codegen/src/isa/zkasm/lower.isle
@@ -57,12 +57,18 @@
 (rule 1 (lower (has_type (fits_in_32 (ty_int ty)) (isub x y)))
   (rv_subw x y))
 
-;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Rules for `ineg`/`bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (ineg val))
   (let
     ((result WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Ineg result (value_regs_get val 0)))))
+    (output_xreg result)))
+
+(rule (lower (bnot val))
+  (let
+    ((result WritableXReg (temp_writable_xreg))
+      (_ Unit (emit (MInst.Bnot result (value_regs_get val 0)))))
     (output_xreg result)))
 
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This is binary not (~x in C or !x in Rust.) WASM does not produce this specific instruction and lowers it to `xor` usually, but in zkasm it is better for us to use subtraction instead – as it is faster.

I believe this should produce equivalent results for all inputs.

Fixes https://github.com/near/wasmtime/issues/66

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
