### PR TITLE
filetests: allow for running clift filetests on non-host ISA

### DIFF
--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 [dependencies]
 # TODO(nearcore/#9569): Add "zkasm" feature to top-level crate.
 capstone.workspace = true
-cranelift-codegen = { workspace = true, features = ["disas", "zkasm"] }
+cranelift-codegen = { workspace = true, features = ["disas", "all-arch"] }
 cranelift-frontend = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-native = { workspace = true }

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target riscv64 has_m
 target riscv64 has_c has_zcb
+target zkasm
 
 function %add_i64(i64, i64) -> i64 {
 block0(v0: i64,v1: i64):


### PR DESCRIPTION
zkasm supports running tests on any architecture that can run nodejs which is somewhat unique in terms of ISAs that cranelift filetest runner supports.

For now things still do not work though, as there appear to be attempts to generate a trampoline. That’s becasue the rest of the infrastructure still assumes this is going to be JITd, loaded into memory directly and called… directly. Whereas for zkasm we must call an external process, unfortunately.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
