### PR TITLE
Add zkevm-proverjs as a submodule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '20.8.0'
-    - run: ./ci/test-zkasm.sh --install-zkwasm --all
+    - run: ./ci/test-zkasm.sh --all
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
     - uses: actions/setup-node@v3
       with:
         node-version: '20.8.0'

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
 	path = tests/wasi_testsuite/wasi-common
 	url = https://github.com/WebAssembly/wasi-testsuite.git
 	branch = prod/testsuite-base
+[submodule "deps/zkevm-proverjs"]
+	path = deps/zkevm-proverjs
+	url = https://github.com/0xPolygonHermez/zkevm-proverjs/
+	branch = feature/64bits

--- a/ci/test-zkasm.sh
+++ b/ci/test-zkasm.sh
@@ -31,9 +31,11 @@ if [ "$ALL_FILES" = false ] && [ -z "$1" ]; then
     exit 1
 fi
 
-BASE_DIR="."
+BASE_DIR="./../../"
+cd deps/zkevm-proverjs
+npm i
 
-NODE_CMD="node deps/zkevm-proverjs/test/zkasmtest.js --rows 2**18"
+NODE_CMD="node test/zkasmtest.js --rows 2**18"
 
 if [ "$ALL_FILES" = false ]; then
     $NODE_CMD "$BASE_DIR/$1"

--- a/ci/test-zkasm.sh
+++ b/ci/test-zkasm.sh
@@ -9,19 +9,16 @@ set -o pipefail
 set -eux
 
 # Flags and default modes
-PREINSTALLED=true
 ALL_FILES=false
 
 # Parse flags
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --all) ALL_FILES=true; shift ;;
-        --install-zkwasm) PREINSTALLED=false; shift ;;
         --help)
             echo "Usage: $0 [OPTIONS] [filename.zkasm]"
             echo "Options:"
             echo "  --all                           Test all zkasm files"
-            echo "  --install-zkwasm                Temporarily install and use zkevm-rom"
             echo "  --help                          Show this message"
             exit 0
             ;;
@@ -34,21 +31,9 @@ if [ "$ALL_FILES" = false ] && [ -z "$1" ]; then
     exit 1
 fi
 
-BASE_DIR="../wasmtime"
+BASE_DIR="."
 
-if [ "$PREINSTALLED" = false ]; then
-    echo "Cloning zkevm-proverjs into /tmp directory..."
-    git clone https://github.com/0xPolygonHermez/zkevm-proverjs/ ./tmp/zkevm-proverjs > /dev/null 2>&1
-    cd ./tmp/zkevm-proverjs
-    npm install
-    BASE_DIR="../.."
-else
-    cd ../zkevm-proverjs
-fi
-
-git checkout feature/64bits
-
-NODE_CMD="node test/zkasmtest.js --rows 2**18"
+NODE_CMD="node deps/zkevm-proverjs/test/zkasmtest.js --rows 2**18"
 
 if [ "$ALL_FILES" = false ]; then
     $NODE_CMD "$BASE_DIR/$1"


### PR DESCRIPTION
This PR adds zkevm-proverjs as a submodule

This simplifies the development setup both locally and on CI, as we
don't need to clone zkevm-proverjs as an explicit step.

Given that we don't plan to directly merge back into wasmtime upstream, I think it's fine to deviate in more major ways from the existing test infrastructure if this gives us productivity gains.