### PR TITLE
Switch to 64bit proverjs

### DIFF
--- a/tests/zkasm/package-lock.json
+++ b/tests/zkasm/package-lock.json
@@ -54,13 +54,12 @@
     },
     "node_modules/@0xpolygonhermez/zkevm-proverjs": {
       "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/0xPolygonHermez/zkevm-proverjs.git#5f0d122fdfb5e3e5b17f45976e08fd26c9f248ba",
-      "integrity": "sha512-AnUPD/K+Eso8puDSqPdvjkj7g1aDfEKrbXKIDotcPFm4dU9zcGb+FRbMvbnqfL/EdZ3t/qOyEjZL9ImBrapySg==",
+      "resolved": "git+ssh://git@github.com/0xPolygonHermez/zkevm-proverjs.git#b4e0ae701f12738fdccf0e46209cae54cbca2c8c",
       "dev": true,
       "license": "UNLICENSED",
       "dependencies": {
-        "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#v1.0.0",
-        "@0xpolygonhermez/zkevm-commonjs": "https://github.com/0xpolygonhermez/zkevm-commonjs.git#v1.1.0-rc.4",
+        "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#feature/64bits",
+        "@0xpolygonhermez/zkevm-commonjs": "https://github.com/0xpolygonhermez/zkevm-commonjs.git#feature/forkid-6-blockhash",
         "@0xpolygonhermez/zkevm-rom": "https://github.com/0xPolygonHermez/zkevm-rom.git#v1.1.0-fork.4",
         "@0xpolygonhermez/zkevm-storage-rom": "https://github.com/0xPolygonHermez/zkevm-storage-rom.git#v1.0.0-fork.3",
         "@grpc/grpc-js": "^1.8.14",

--- a/tests/zkasm/package.json
+++ b/tests/zkasm/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "test": "node run-tests-zkasm.js"
   },
-  "keywords": [
-  ],
+  "keywords": [],
   "author": "Andrei Kashin",
   "license": "AGPL",
   "dependencies": {
@@ -14,8 +13,8 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/64bits",
     "@0xpolygonhermez/zkevm-commonjs": "github:0xPolygonHermez/zkevm-commonjs#v2.0.0-fork.5",
+    "@0xpolygonhermez/zkevm-proverjs": "github:0xPolygonHermez/zkevm-proverjs#feature/64bits",
     "chai": "^4.3.6",
     "chalk": "^3.0.0",
     "eslint": "^8.25.0",


### PR DESCRIPTION
This makes sure we use 64bit branch for zkevm-proverjs. Thanks to @MCJOHN974 for catching this