### PR TITLE
zkasm: remove Lui and Auipc code

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst.isle
+++ b/cranelift/codegen/src/isa/zkasm/inst.isle
@@ -9,11 +9,6 @@
     (Label
       (imm usize))
 
-    ;; load immediate
-    (Lui
-      (rd WritableReg)
-      (imm Imm20))
-
     (LoadConst32
       (rd WritableReg)
       (imm u32))
@@ -21,11 +16,6 @@
     (LoadConst64
       (rd WritableReg)
       (imm u64))
-
-     (Auipc
-      (rd WritableReg)
-      (imm Imm20))
-
 
     ;; An ALU operation with two register sources and a register destination.
     (AluRRR

--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -427,11 +427,6 @@ impl MachInstEmit for Inst {
                 // for more information see https://github.com/bytecodealliance/wasmtime/pull/5612.
                 todo!() // sink.put_data(&data[..]);
             }
-            &Inst::Lui { rd, ref imm } => {
-                todo!() /* let rd = allocs.next_writable(rd);
-                        let x: u32 = 0b0110111 | reg_to_gpr_num(rd.to_reg()) << 7 | (imm.as_u32() << 12);
-                        sink.put4(x); */
-            }
             &Inst::LoadConst32 { rd, imm } => {
                 let rd = allocs.next_writable(rd);
                 put_string(&format!("{imm} => {}\n", reg_name(rd.to_reg())), sink);
@@ -1068,12 +1063,6 @@ impl MachInstEmit for Inst {
                         // Compute the jump table offset.
                         // We need to emit a PC relative offset,
 
-                        // Get the current PC.
-                        Inst::Auipc {
-                            rd: tmp1,
-                            imm: Imm20::from_bits(0),
-                        }
-                        .emit(&[], sink, emit_info, state);
 
                         // Multiply the index by 8, since that is the size in
                         // bytes of each jump table entry
@@ -1142,11 +1131,6 @@ impl MachInstEmit for Inst {
                 //     state.virtual_sp_offset + amount
                 //     );
                 // state.virtual_sp_offset += amount;
-            }
-            &Inst::Auipc { rd, imm } => {
-                todo!() /* let rd = allocs.next_writable(rd);
-                        let x = enc_auipc(rd, imm);
-                        sink.put4(x); */
             }
 
             &Inst::LoadAddr { rd, mem } => {

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -261,8 +261,6 @@ fn zkasm_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
             collector.reg_early_def(tmp1);
             collector.reg_early_def(tmp2);
         }
-        &Inst::Auipc { rd, .. } => collector.reg_def(rd),
-        &Inst::Lui { rd, .. } => collector.reg_def(rd),
         &Inst::LoadConst32 { rd, .. } => collector.reg_def(rd),
         &Inst::LoadConst64 { rd, .. } => collector.reg_def(rd),
         &Inst::AluRRR { rd, rs1, rs2, .. } => {
@@ -948,21 +946,10 @@ impl Inst {
                     format_reg(tmp2.to_reg(), allocs),
                 )
             }
-            &Inst::Auipc { rd, imm } => {
-                format!(
-                    "{} {},{}",
-                    "auipc",
-                    format_reg(rd.to_reg(), allocs),
-                    imm.bits
-                )
-            }
             &Inst::Jalr { rd, base, offset } => {
                 let base = format_reg(base, allocs);
                 let rd = format_reg(rd.to_reg(), allocs);
                 format!("{} {},{}({})", "jalr", rd, offset.bits, base)
-            }
-            &Inst::Lui { rd, ref imm } => {
-                format!("{} {},{}", "lui", format_reg(rd.to_reg(), allocs), imm.bits)
             }
             &Inst::LoadConst32 { rd, imm } => {
                 let rd = format_reg(rd.to_reg(), allocs);


### PR DESCRIPTION
The Lui is currently correctly replaced by `LoadConst*` instructions and `Auipc` is not really relevant to zkasm (I believe it is largely useful for relocations and loading data at locations further away than 20 or 12 bytes, whichever one it is.)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
