### PR TITLE
Add summary file with test results

### DIFF
--- a/ci/zkasm-result.py
+++ b/ci/zkasm-result.py
@@ -4,7 +4,11 @@ import sys
 import argparse
 import json
 import logging
+from operator import countOf
 
+
+CSV_FIELD_NAMES = ['Test', 'Status']
+TEST_SUMMARY_FILE_PATH = "docs/zkasm/test_summary.csv"
 
 parser = argparse.ArgumentParser(description='Example script to demonstrate flag usage.')
 parser.add_argument('path', type=str, help='Path to a folder with tests')
@@ -33,29 +37,48 @@ def update_status_from_stdin(status_map):
         status_map[test_name] = test_result["status"]
 
 
+def read_summary(filepath):
+    with open(filepath, 'r', newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        return {row['Suite path']: row for row in reader}
+
+
+def write_summary(filepath, summary):
+    with open(filepath, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames = ['Suite path', 'Passing count', 'Total count'])
+        writer.writeheader()
+        for (path, value) in sorted(summary.items()):
+            writer.writerow({'Suite path': path, **value})
+
+
 def write_csv(status_map):
     with open(state_csv_path, 'w', newline='') as csvfile:
-        csvwriter = csv.writer(csvfile)
-        csvwriter.writerow(['Test', 'Status'])
-        status_list = sorted(status_map.items())
-        csvwriter.writerows(status_list)
-        csvwriter.writerow(['Total Passed', sum(1 for status in status_map.values() if status == 'pass')])
-        csvwriter.writerow(['Amount of Tests', len(status_map)])
+        writer = csv.DictWriter(csvfile, fieldnames = CSV_FIELD_NAMES)
+        writer.writeheader()
+        for (test_name, test_status) in sorted(status_map.items()):
+            writer.writerow({'Test': test_name, 'Status': test_status})
+
+    if os.path.exists(TEST_SUMMARY_FILE_PATH):
+        summary = read_summary(TEST_SUMMARY_FILE_PATH)
+    else:
+        summary = {}
+
+    summary[tests_path] = {
+        'Passing count': countOf(status_map.values(), "pass"),
+        'Total count': len(status_map),
+    }
+    write_summary(TEST_SUMMARY_FILE_PATH, summary)
 
 
 def assert_with_csv(status_map):
     with open(state_csv_path, newline='') as csvfile:
-        csvreader = csv.reader(csvfile)
-        csv_dict = {}
-        for row in csvreader:
-            if row[0] in ["Test", "Total Passed", "Amount of Tests"]:
-                continue
-            csv_dict[row[0]] = row[1]
-        if csv_dict != status_map:
-            diff = set(csv_dict.items()) ^ set(status_map.items())
+        reader = csv.DictReader(csvfile)
+        test_results = {row['Test']: row['Status'] for row in reader}
+        if test_results != status_map:
+            diff = set(test_results.items()) ^ set(status_map.items())
             diff_keys = set(map(lambda x: x[0], diff))
             for key in diff_keys:
-                logging.info(f"Update for test {key}: {csv_dict[key]} => {status_map[key]}")
+                logging.info(f"Update for test {key}: {test_results[key]} => {status_map[key]}")
             return 1
     return 0
 

--- a/cranelift/zkasm_data/spectest/i32/state.csv
+++ b/cranelift/zkasm_data/spectest/i32/state.csv
@@ -363,5 +363,3 @@ xor_6,pass
 xor_7,pass
 xor_8,pass
 xor_9,pass
-Total Passed,127
-Amount of Tests,364

--- a/cranelift/zkasm_data/spectest/i64/state.csv
+++ b/cranelift/zkasm_data/spectest/i64/state.csv
@@ -373,5 +373,3 @@ xor_6,pass
 xor_7,pass
 xor_8,pass
 xor_9,pass
-Total Passed,133
-Amount of Tests,374

--- a/cranelift/zkasm_data/state.csv
+++ b/cranelift/zkasm_data/state.csv
@@ -25,5 +25,3 @@ nop,pass
 or,pass
 rem,pass
 xor,pass
-Total Passed,25
-Amount of Tests,26

--- a/docs/zkasm/test_summary.csv
+++ b/docs/zkasm/test_summary.csv
@@ -1,0 +1,4 @@
+Suite path,Passing count,Total count
+cranelift/zkasm_data,25,26
+cranelift/zkasm_data/spectest/i32,127,364
+cranelift/zkasm_data/spectest/i64,133,374


### PR DESCRIPTION
This PR moves the number of passing tests to a separate CSV file.
This allows to find the results of all tests in a single file as well as simplify file parsing for test results of individual test suites.