### PR TITLE
Implement `lower_br_icmp`

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -275,8 +275,7 @@ impl Inst {
         not_taken: BranchTarget,
         ty: Type,
     ) -> SmallInstVec<Inst> {
-        todo!()
-        /* let mut insts = SmallInstVec::new();
+        let mut insts = SmallInstVec::new();
         if ty.bits() <= 64 {
             let rs1 = a.only_reg().unwrap();
             let rs2 = b.only_reg().unwrap();
@@ -288,6 +287,8 @@ impl Inst {
             insts.push(inst);
             return insts;
         }
+        unimplemented!("lower_br_icmp: ty={ty:?}")
+        /*
         // compare i128
         let low = |cc: IntCC| -> IntegerCompare {
             IntegerCompare {

--- a/cranelift/zkasm_data/benchmarks/fibonacci/generated/from_rust.zkasm
+++ b/cranelift/zkasm_data/benchmarks/fibonacci/generated/from_rust.zkasm
@@ -1,0 +1,79 @@
+start:
+  zkPC + 2 => RR
+  :JMP(function_1)
+  :JMP(finalizeExecution)
+function_1:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 5 => SP
+  C :MSTORE(SP - 1)
+  D :MSTORE(SP - 2)
+  E :MSTORE(SP - 3)
+  B :MSTORE(SP - 4)
+  1n => C
+  0n => B
+  42949672960000n => A
+  A => E
+  C => A
+  :JMP(label_1_1)
+label_1_1:
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => C :ADD
+  A => B
+  C => A
+  $ => D :ADD
+  A :MSTORE(SP)
+  18446744030759878656n => B
+  E => A
+  $ => A :ADD
+  A => C
+  A => E
+  C => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_1_2)
+  :JMP(label_1_3)
+label_1_2:
+  C => E
+  $ => B :MLOAD(SP)
+  D => A
+  :JMP(label_1_1)
+label_1_3:
+  15574651946073070043n => B
+  $ => A :MLOAD(SP)
+  B :ASSERT
+  $ => C :MLOAD(SP - 1)
+  $ => D :MLOAD(SP - 2)
+  $ => E :MLOAD(SP - 3)
+  $ => B :MLOAD(SP - 4)
+  SP - 5 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+finalizeExecution:
+  ${beforeLast()}  :JMPN(finalizeExecution)
+                   :JMP(start)
+INCLUDE "helpers/2-exp.zkasm"

--- a/cranelift/zkasm_data/benchmarks/fibonacci/state.csv
+++ b/cranelift/zkasm_data/benchmarks/fibonacci/state.csv
@@ -1,3 +1,3 @@
 Test,Status,Cycles
-from_rust,compilation failed,
+from_rust,pass,42024
 handwritten_wat,pass,190024

--- a/docs/zkasm/test_summary.csv
+++ b/docs/zkasm/test_summary.csv
@@ -1,6 +1,6 @@
 Suite path,Passing count,Total count,Total cycles
 cranelift/zkasm_data,25,26,1023
-cranelift/zkasm_data/benchmarks/fibonacci,1,2,190024
+cranelift/zkasm_data/benchmarks/fibonacci,2,2,232048
 cranelift/zkasm_data/spectest/conversions,3,24,45
 cranelift/zkasm_data/spectest/i32,197,364,5835
 cranelift/zkasm_data/spectest/i64,203,374,5022


### PR DESCRIPTION
This was missing to make Fibonacci benchmark run