### PR TITLE
Tweak worst case size

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -784,7 +784,7 @@ impl MachInst for Inst {
 
     fn worst_case_size() -> CodeOffset {
         // calculate by test function zkasm_worst_case_instruction_size()
-        1_000_000
+        1_155
     }
 
     fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {

--- a/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
+++ b/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
@@ -1,0 +1,58203 @@
+start:
+  zkPC + 2 => RR
+  :JMP(function_1)
+  :JMP(finalizeExecution)
+function_1:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 16 => SP
+  C :MSTORE(SP - 1)
+  D :MSTORE(SP - 2)
+  E :MSTORE(SP - 3)
+  B :MSTORE(SP - 4)
+  $ => A :MLOAD(CTX + 8)
+  1030792151040n => B
+  $ => A :SUB
+  A :MSTORE(SP + 88)
+  A :MSTORE(CTX + 8)
+  34359738368n => B
+  $ => E :ADD
+  E => A
+  34359738368n => B
+  $ => B :ADD
+  0n => E
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  B :MSTORE(SP)
+  E :MSTORE(A)
+  34359738368n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => A
+  68719476736n => B
+  $ => B :ADD
+  B :MSTORE(SP + 80)
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  C :MSTORE(A)
+  34359738368n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => A
+  103079215104n => B
+  $ => B :ADD
+  B :MSTORE(SP + 72)
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => D :ADD
+  C :MSTORE(D)
+  171798691840n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B :MSTORE(SP + 64)
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => D :ADD
+  C :MSTORE(D)
+  34359738368n => B
+  $ => A :MLOAD(SP + 88)
+  $ => C :ADD
+  C => A
+  171798691840n => B
+  $ => B :ADD
+  B :MSTORE(SP + 56)
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => D :ADD
+  C :MSTORE(D)
+  227633266688n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B :MSTORE(SP + 48)
+  0n => D
+  $ => A :MLOAD(CTX)
+  $ => E :ADD
+  D :MSTORE(E)
+  0n => E
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => A :ADD
+  E :MSTORE(A + 8)
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => A
+  103079215104n => B
+  $ => B :ADD
+  B => D
+  0n => B
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  $ => C :MLOAD(A + 1048600)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => A :ADD
+  C :MSTORE(A)
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => A
+  68719476736n => B
+  $ => B :ADD
+  B => D
+  0n => B
+  $ => A :MLOAD(CTX)
+  $ => B :ADD
+  $ => C :MLOAD(B + 1048592)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => B :ADD
+  C :MSTORE(B)
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => C :ADD
+  C => A
+  34359738368n => B
+  $ => B :ADD
+  B => D
+  0n => B
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => C :MLOAD(C + 1048584)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => D :ADD
+  C :MSTORE(D)
+  476741369856n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => D
+  0n => B
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => C :MLOAD(C + 1048615)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => D :ADD
+  C :MSTORE(D)
+  0n => B
+  $ => A :MLOAD(CTX)
+  $ => D :ADD
+  $ => D :MLOAD(D + 1048576)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => E :ADD
+  D :MSTORE(E + 64)
+  0n => E
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  E :MSTORE(A + 96)
+  0n => B
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  $ => C :MLOAD(A + 1048608)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => A :ADD
+  C :MSTORE(A + 104)
+  493921239040n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B :MSTORE(SP + 40)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => C :ADD
+  $ => C :MLOAD(C + 8)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 40)
+  $ => D :ADD
+  C :MSTORE(D)
+  528280977408n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => D
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP)
+  $ => C :ADD
+  $ => C :MLOAD(C)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => D :ADD
+  C :MSTORE(D)
+  562640715776n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => D
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 80)
+  $ => C :ADD
+  $ => C :MLOAD(C)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => D :ADD
+  C :MSTORE(D)
+  597000454144n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => E
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 72)
+  $ => D :ADD
+  $ => D :MLOAD(D)
+  $ => A :MLOAD(CTX)
+  E => B
+  $ => E :ADD
+  D :MSTORE(E)
+  631360192512n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => C
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 64)
+  $ => E :ADD
+  $ => E :MLOAD(E)
+  $ => A :MLOAD(CTX)
+  C => B
+  $ => A :ADD
+  E :MSTORE(A)
+  665719930880n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => D
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 56)
+  $ => A :ADD
+  $ => C :MLOAD(A)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => A :ADD
+  C :MSTORE(A)
+  687194767360n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => E
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 48)
+  $ => C :ADD
+  $ => C :MLOAD(C)
+  $ => A :MLOAD(CTX)
+  E => B
+  $ => B :ADD
+  C :MSTORE(B)
+  47244640256n => C
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => D :ADD
+  C :MSTORE(D + 168)
+  738734374912n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => D
+  17179869184n => B
+  $ => B :ADD
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => C :MLOAD(C)
+  $ => A :MLOAD(CTX)
+  D => B
+  $ => D :ADD
+  C :MSTORE(D)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => D :ADD
+  $ => D :MLOAD(D + 1)
+  $ => A :MLOAD(CTX)
+  $ => E :ADD
+  D :MSTORE(E + 169)
+  549755813888n => E
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 40)
+  $ => A :ADD
+  E :MSTORE(A)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => A :ADD
+  $ => A :MLOAD(A + 96)
+  9n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 32)
+  A :MSTORE(SP + 40)
+  88n => B
+  $ => A :MLOAD(SP + 32)
+  $ => B :OR
+  B :MSTORE(SP + 24)
+  65024n => B
+  $ => A :MLOAD(SP + 24)
+  $ => B :AND
+  B => A
+  40n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 16)
+  16711680n => B
+  $ => A :MLOAD(SP + 24)
+  $ => B :AND
+  B => A
+  24n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 8)
+  4278190080n => B
+  $ => A :MLOAD(SP + 24)
+  $ => A :AND
+  8n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 8)
+  E => B
+  $ => B :OR
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  A :MSTORE(SP + 8)
+  1n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => A
+  4278190080n => B
+  $ => A :AND
+  A :MSTORE(SP)
+  15n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  16711680n => B
+  $ => B :AND
+  $ => A :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP)
+  31n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  65280n => B
+  $ => A :AND
+  A :MSTORE(SP + 80)
+  56n => E
+  $ => A :MLOAD(SP + 32)
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  A => B
+  $ => A :MLOAD(SP + 80)
+  $ => B :OR
+  $ => A :MLOAD(SP)
+  $ => B :OR
+  $ => A :MLOAD(SP + 8)
+  $ => A :OR
+  A => E
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => A
+  171798691840n => B
+  $ => B :ADD
+  B :MSTORE(SP + 80)
+  0n => A
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_1_1)
+  :JMP(label_1_2)
+label_1_1:
+  :JMP(label_1_3)
+label_1_2:
+  47244640256n => A
+  $ => B :MLOAD(SP + 80)
+  $ => A :ADD
+  4294967296n => B
+  $ => A :ADD
+  0n => B
+  223338299392n => C
+  SP + 1 => SP
+  C :MSTORE(SP)
+  zkPC + 2 => RR
+  :JMP(function_4)
+  SP - 1 => SP
+  :JMP(label_1_3)
+label_1_3:
+  6341068275337658368n => B
+  E => A
+  $ => E :OR
+  47244640256n => A
+  240518168576n => B
+  $ => A :XOR
+  34359738368n => B
+  $ => A :LT
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_1_5)
+  687194767360n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  E :MSTORE(C)
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => D :ADD
+  D => A
+  4294967296n => D
+  SP + 1 => SP
+  D :MSTORE(SP)
+  $ => B :MLOAD(SP + 80)
+  zkPC + 2 => RR
+  :JMP(function_2)
+  SP - 1 => SP
+  :JMP(label_1_6)
+label_1_5:
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => A
+  4294967296n => C
+  SP + 1 => SP
+  C :MSTORE(SP)
+  $ => B :MLOAD(SP + 80)
+  zkPC + 2 => RR
+  :JMP(function_2)
+  SP - 1 => SP
+  962072674304n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  C :MSTORE(A)
+  927712935936n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  C :MSTORE(A)
+  893353197568n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => B :ADD
+  C :MSTORE(B)
+  858993459200n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => D :ADD
+  C :MSTORE(D)
+  824633720832n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => D :ADD
+  C :MSTORE(D)
+  790273982464n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  0n => D
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  D :MSTORE(A)
+  0n => C
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => A :ADD
+  C :MSTORE(A + 176)
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  E :MSTORE(A + 232)
+  274877906944n => B
+  $ => A :MLOAD(SP + 88)
+  $ => B :ADD
+  B => D
+  755914244096n => B
+  $ => B :ADD
+  4294967296n => C
+  SP + 1 => SP
+  C :MSTORE(SP)
+  D => A
+  zkPC + 2 => RR
+  :JMP(function_2)
+  SP - 1 => SP
+  :JMP(label_1_6)
+label_1_6:
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => C :ADD
+  $ => A :MLOAD(C + 92)
+  A :MSTORE(SP + 80)
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => A :MLOAD(C + 88)
+  A :MSTORE(SP + 72)
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => A :MLOAD(C + 84)
+  A :MSTORE(SP + 64)
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => A :MLOAD(C + 80)
+  A :MSTORE(SP + 56)
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => A :MLOAD(C + 76)
+  A :MSTORE(SP + 48)
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => A :MLOAD(C + 72)
+  A :MSTORE(SP + 40)
+  $ => A :MLOAD(CTX)
+  $ => C :ADD
+  $ => A :MLOAD(C + 64)
+  A :MSTORE(SP + 32)
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 16)
+  280375465082880n => B
+  $ => C :AND
+  C => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 16)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP)
+  B :MSTORE(SP + 8)
+  34359738368n => E
+  $ => A :MLOAD(SP + 32)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 24)
+  103079215104n => E
+  $ => A :MLOAD(SP + 32)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 24)
+  $ => C :OR
+  $ => A :MLOAD(SP)
+  B => D
+  C => B
+  $ => A :OR
+  A :MSTORE(SP + 24)
+  280375465082880n => B
+  $ => C :AND
+  C :MSTORE(SP + 16)
+  68719476736n => E
+  D => A
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 16)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 16)
+  68719476736n => E
+  $ => A :MLOAD(SP + 8)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  32n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 16)
+  18374686479671623680n => B
+  $ => A :MLOAD(SP + 24)
+  $ => A :AND
+  A :MSTORE(SP + 8)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP + 88)
+  $ => C :ADD
+  $ => A :MLOAD(C + 68)
+  A :MSTORE(SP)
+  103079215104n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  68719476736n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 8)
+  E => B
+  $ => B :OR
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  A :MSTORE(SP + 24)
+  34359738368n => E
+  $ => A :MLOAD(SP)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 16)
+  280375465082880n => B
+  $ => A :MLOAD(SP)
+  $ => C :AND
+  C => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => A
+  68719476736n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 16)
+  $ => B :OR
+  $ => A :MLOAD(SP + 24)
+  $ => A :OR
+  8n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => C
+  1095216660480n => B
+  $ => A :MLOAD(SP)
+  $ => B :AND
+  C => A
+  $ => A :OR
+  13352372148217134600n => B
+  B :ASSERT
+  103079215104n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 16)
+  280375465082880n => B
+  $ => C :AND
+  C => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 16)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP)
+  B :MSTORE(SP + 8)
+  34359738368n => E
+  $ => A :MLOAD(SP + 40)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 24)
+  103079215104n => E
+  $ => A :MLOAD(SP + 40)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 24)
+  $ => C :OR
+  $ => A :MLOAD(SP)
+  B => D
+  C => B
+  $ => A :OR
+  A :MSTORE(SP + 24)
+  280375465082880n => B
+  $ => C :AND
+  C :MSTORE(SP + 16)
+  68719476736n => E
+  D => A
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 16)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 16)
+  68719476736n => E
+  $ => A :MLOAD(SP + 8)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  32n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 16)
+  18374686479671623680n => B
+  $ => A :MLOAD(SP + 24)
+  $ => A :AND
+  A :MSTORE(SP + 8)
+  103079215104n => E
+  $ => A :MLOAD(SP + 48)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  68719476736n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 8)
+  E => B
+  $ => B :OR
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  A :MSTORE(SP + 8)
+  34359738368n => E
+  $ => A :MLOAD(SP + 48)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP)
+  280375465082880n => B
+  $ => A :MLOAD(SP + 48)
+  $ => C :AND
+  C => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => A
+  68719476736n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP)
+  $ => B :OR
+  $ => A :MLOAD(SP + 8)
+  $ => A :OR
+  8n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => C
+  1095216660480n => B
+  $ => A :MLOAD(SP + 48)
+  $ => B :AND
+  C => A
+  $ => A :OR
+  11902541952223915002n => B
+  B :ASSERT
+  103079215104n => E
+  $ => A :MLOAD(SP + 56)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP)
+  280375465082880n => B
+  $ => D :AND
+  D => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 8)
+  B :MSTORE(SP + 24)
+  34359738368n => E
+  $ => A :MLOAD(SP + 56)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP)
+  103079215104n => E
+  $ => A :MLOAD(SP + 56)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP)
+  $ => D :OR
+  $ => A :MLOAD(SP + 8)
+  B => C
+  D => B
+  $ => A :OR
+  A :MSTORE(SP)
+  280375465082880n => B
+  $ => D :AND
+  D :MSTORE(SP + 16)
+  68719476736n => E
+  C => A
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 16)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 16)
+  68719476736n => E
+  $ => A :MLOAD(SP + 24)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  32n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 16)
+  18374686479671623680n => B
+  $ => A :MLOAD(SP)
+  $ => A :AND
+  A :MSTORE(SP + 8)
+  103079215104n => E
+  $ => A :MLOAD(SP + 64)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  68719476736n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 8)
+  E => B
+  $ => B :OR
+  $ => A :MLOAD(SP + 16)
+  $ => A :OR
+  A :MSTORE(SP + 8)
+  34359738368n => E
+  $ => A :MLOAD(SP + 64)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP)
+  280375465082880n => B
+  $ => A :MLOAD(SP + 64)
+  $ => D :AND
+  D => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => A
+  68719476736n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP)
+  $ => B :OR
+  $ => A :MLOAD(SP + 8)
+  $ => A :OR
+  8n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => C
+  1095216660480n => B
+  $ => A :MLOAD(SP + 64)
+  $ => B :AND
+  C => A
+  $ => A :OR
+  14160706888648589550n => B
+  B :ASSERT
+  103079215104n => E
+  $ => A :MLOAD(SP + 72)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP)
+  280375465082880n => B
+  $ => E :AND
+  E => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP)
+  B :MSTORE(SP + 16)
+  34359738368n => E
+  $ => A :MLOAD(SP + 72)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 8)
+  103079215104n => E
+  $ => A :MLOAD(SP + 72)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 8)
+  $ => E :OR
+  $ => A :MLOAD(SP)
+  B => C
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 8)
+  280375465082880n => B
+  $ => E :AND
+  E :MSTORE(SP)
+  68719476736n => E
+  C => A
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP)
+  68719476736n => E
+  $ => A :MLOAD(SP + 16)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP)
+  $ => A :OR
+  32n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP)
+  18374686479671623680n => B
+  $ => A :MLOAD(SP + 8)
+  $ => A :AND
+  A :MSTORE(SP + 8)
+  103079215104n => E
+  $ => A :MLOAD(SP + 80)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  68719476736n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 8)
+  E => B
+  $ => B :OR
+  $ => A :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 8)
+  34359738368n => E
+  $ => A :MLOAD(SP + 80)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP)
+  280375465082880n => B
+  $ => A :MLOAD(SP + 80)
+  $ => E :AND
+  E => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => A
+  68719476736n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP)
+  $ => B :OR
+  $ => A :MLOAD(SP + 8)
+  $ => A :OR
+  8n => E
+  A :MSTORE(SP)
+  64 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E => C
+  1095216660480n => B
+  $ => A :MLOAD(SP + 80)
+  $ => B :AND
+  C => A
+  $ => A :OR
+  10414846460208074217n => B
+  B :ASSERT
+  1030792151040n => B
+  $ => A :MLOAD(SP + 88)
+  $ => A :ADD
+  A :MSTORE(CTX + 8)
+  $ => C :MLOAD(SP - 1)
+  $ => D :MLOAD(SP - 2)
+  $ => E :MLOAD(SP - 3)
+  $ => B :MLOAD(SP - 4)
+  SP - 16 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+function_2:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  C :MSTORE(SP - 1)
+  $ => C :MLOAD(fp + 16)
+  SP + 1 => SP
+  C :MSTORE(SP)
+  zkPC + 2 => RR
+  :JMP(function_3)
+  SP - 1 => SP
+  $ => C :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+function_3:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 357 => SP
+  C :MSTORE(SP - 1)
+  D :MSTORE(SP - 2)
+  E :MSTORE(SP - 3)
+  B :MSTORE(SP - 4)
+  CTX :MSTORE(SP - 5)
+  A :MSTORE(SP)
+  B :MSTORE(SP + 8)
+  $ => A :MLOAD(fp + 16)
+  A :MSTORE(SP + 16)
+  $ => A :MLOAD(CTX)
+  $ => B :MLOAD(SP)
+  $ => A :ADD
+  $ => C :MLOAD(A + 28)
+  C :MSTORE(SP + 72)
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  $ => A :MLOAD(A + 24)
+  A :MSTORE(SP + 80)
+  $ => A :MLOAD(CTX)
+  $ => A :ADD
+  $ => D :MLOAD(A + 20)
+  D :MSTORE(SP + 88)
+  $ => A :MLOAD(CTX)
+  CTX :MSTORE(SP + 24)
+  $ => A :ADD
+  $ => C :MLOAD(A + 16)
+  $ => E :MLOAD(SP + 24)
+  C :MSTORE(SP + 96)
+  $ => A :MLOAD(E)
+  $ => A :ADD
+  $ => A :MLOAD(A + 12)
+  A :MSTORE(SP + 104)
+  $ => A :MLOAD(E)
+  $ => A :ADD
+  $ => D :MLOAD(A + 8)
+  D :MSTORE(SP + 112)
+  $ => A :MLOAD(E)
+  $ => A :ADD
+  $ => C :MLOAD(A + 4)
+  C :MSTORE(SP + 120)
+  $ => A :MLOAD(E)
+  $ => A :ADD
+  $ => B :MLOAD(A)
+  B :MSTORE(SP + 128)
+  0n => B
+  $ => A :MLOAD(SP + 16)
+  $ => A :EQ
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_3_1)
+  :JMP(label_3_2)
+label_3_1:
+  $ => A :MLOAD(SP + 24)
+  $ => CTX :MLOAD(SP + 72)
+  :JMP(label_3_7)
+label_3_2:
+  25769803776n => E
+  $ => A :MLOAD(SP + 16)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 8)
+  E => B
+  $ => CTX :ADD
+  CTX :MSTORE(SP + 2800)
+  A :MSTORE(SP + 64)
+  $ => C :MLOAD(SP + 88)
+  C :MSTORE(SP + 56)
+  $ => C :MLOAD(SP + 80)
+  C :MSTORE(SP + 48)
+  $ => C :MLOAD(SP + 96)
+  C :MSTORE(SP + 40)
+  $ => C :MLOAD(SP + 72)
+  C :MSTORE(SP + 32)
+  $ => C :MLOAD(SP + 120)
+  C :MSTORE(SP + 16)
+  $ => C :MLOAD(SP + 112)
+  C :MSTORE(SP + 8)
+  $ => B :MLOAD(SP + 120)
+  $ => A :MLOAD(SP + 112)
+  :JMP(label_3_3)
+label_3_3:
+  $ => CTX :XOR
+  CTX => A
+  $ => B :MLOAD(SP + 128)
+  $ => A :AND
+  $ => B :MLOAD(SP + 16)
+  A => E
+  $ => A :MLOAD(SP + 8)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => A :XOR
+  A => CTX
+  128849018880n => E
+  $ => A :MLOAD(SP + 128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2792)
+  81604378624n => E
+  $ => A :MLOAD(SP + 128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2792)
+  $ => A :XOR
+  A :MSTORE(SP + 2792)
+  42949672960n => E
+  $ => A :MLOAD(SP + 128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2792)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  A :MSTORE(SP + 2792)
+  111669149696n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  90194313216n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  30064771072n => E
+  $ => A :MLOAD(SP + 40)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => B :XOR
+  $ => A :MLOAD(SP + 32)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 48)
+  B => C
+  $ => B :MLOAD(SP + 56)
+  $ => CTX :XOR
+  CTX => A
+  $ => B :MLOAD(SP + 40)
+  $ => A :AND
+  $ => B :MLOAD(SP + 48)
+  $ => CTX :XOR
+  CTX => B
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2784)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2776)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2776)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2776)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2768)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2768)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2776)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2784)
+  $ => A :ADD
+  B :MSTORE(SP + 2768)
+  4794697083170848768n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2792)
+  $ => A :ADD
+  A :MSTORE(SP + 2752)
+  B :MSTORE(SP + 2760)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2752)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2752)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 128)
+  A => E
+  $ => A :MLOAD(SP + 16)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2752)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 16)
+  B => C
+  $ => B :MLOAD(SP + 128)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 2744)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 4)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2736)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2736)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2736)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2728)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2728)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2736)
+  $ => B :OR
+  $ => A :MLOAD(SP + 48)
+  $ => CTX :ADD
+  B :MSTORE(SP + 2728)
+  $ => B :MLOAD(SP + 104)
+  $ => A :MLOAD(SP + 2760)
+  CTX => C
+  $ => A :ADD
+  A :MSTORE(SP + 2720)
+  $ => B :MLOAD(SP + 40)
+  $ => A :MLOAD(SP + 56)
+  $ => CTX :XOR
+  CTX => B
+  $ => A :MLOAD(SP + 2720)
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 56)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2720)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2712)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2720)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2712)
+  $ => A :XOR
+  A :MSTORE(SP + 2712)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2720)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2712)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  8158064639565889536n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2744)
+  $ => A :ADD
+  A :MSTORE(SP + 2704)
+  B :MSTORE(SP + 2712)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2704)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2704)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 128)
+  A => C
+  $ => A :MLOAD(SP + 2752)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2704)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2752)
+  B => D
+  $ => B :MLOAD(SP + 128)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2696)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 8)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2688)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2688)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2688)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2680)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2680)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2688)
+  $ => B :OR
+  $ => A :MLOAD(SP + 56)
+  $ => CTX :ADD
+  B :MSTORE(SP + 2680)
+  $ => B :MLOAD(SP + 8)
+  $ => A :MLOAD(SP + 2712)
+  CTX => E
+  $ => A :ADD
+  A :MSTORE(SP + 2672)
+  $ => B :MLOAD(SP + 40)
+  $ => A :MLOAD(SP + 2720)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2672)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 40)
+  $ => CTX :XOR
+  E => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2664)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2664)
+  $ => A :XOR
+  A :MSTORE(SP + 2664)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2664)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  13096744582870204416n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2696)
+  $ => A :ADD
+  A :MSTORE(SP + 2656)
+  B :MSTORE(SP + 2664)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2752)
+  A => C
+  $ => A :MLOAD(SP + 2704)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2656)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2704)
+  B => D
+  $ => B :MLOAD(SP + 2752)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2648)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 12)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2640)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2640)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2640)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2632)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2632)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2640)
+  $ => B :OR
+  $ => A :MLOAD(SP + 40)
+  $ => CTX :ADD
+  B :MSTORE(SP + 2632)
+  A :MSTORE(SP + 40)
+  $ => B :MLOAD(SP + 16)
+  $ => A :MLOAD(SP + 2664)
+  CTX => C
+  $ => A :ADD
+  A :MSTORE(SP + 2624)
+  $ => B :MLOAD(SP + 2720)
+  $ => A :MLOAD(SP + 2672)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2624)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2720)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2624)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2616)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2624)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2616)
+  $ => A :XOR
+  A :MSTORE(SP + 2616)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2624)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2616)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  16840607883337924608n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2648)
+  $ => A :ADD
+  A :MSTORE(SP + 2608)
+  B :MSTORE(SP + 2616)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2704)
+  A => E
+  $ => A :MLOAD(SP + 2656)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2608)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2656)
+  B => C
+  $ => B :MLOAD(SP + 2704)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 2600)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 16)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2592)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2592)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2592)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2584)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2584)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2592)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2720)
+  $ => A :ADD
+  B :MSTORE(SP + 2584)
+  $ => B :MLOAD(SP + 128)
+  A => C
+  $ => A :MLOAD(SP + 2616)
+  $ => A :ADD
+  A :MSTORE(SP + 2576)
+  $ => B :MLOAD(SP + 2672)
+  $ => A :MLOAD(SP + 2624)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2576)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2672)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2568)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2568)
+  $ => A :XOR
+  A :MSTORE(SP + 2568)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2568)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  4131703404256821248n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2600)
+  $ => A :ADD
+  A :MSTORE(SP + 2560)
+  B :MSTORE(SP + 2568)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2560)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2560)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2656)
+  A => D
+  $ => A :MLOAD(SP + 2608)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2560)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2608)
+  B => C
+  $ => B :MLOAD(SP + 2656)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  D => A
+  $ => A :ADD
+  A :MSTORE(SP + 2552)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 20)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2544)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2544)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2544)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2536)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2536)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2544)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2672)
+  $ => B :ADD
+  A :MSTORE(SP + 2536)
+  $ => A :MLOAD(SP + 2568)
+  B => E
+  $ => B :MLOAD(SP + 2752)
+  $ => A :ADD
+  A :MSTORE(SP + 2528)
+  $ => B :MLOAD(SP + 2624)
+  $ => A :MLOAD(SP + 2576)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2528)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2624)
+  $ => CTX :XOR
+  E => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2520)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2520)
+  $ => A :XOR
+  A :MSTORE(SP + 2520)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2520)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  6480981065547644928n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2552)
+  $ => A :ADD
+  A :MSTORE(SP + 2512)
+  B :MSTORE(SP + 2520)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2512)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2512)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2608)
+  A => C
+  $ => A :MLOAD(SP + 2560)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2512)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2560)
+  B => D
+  $ => B :MLOAD(SP + 2608)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2504)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 24)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2496)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2496)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2496)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2488)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2488)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2496)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2624)
+  $ => B :ADD
+  A :MSTORE(SP + 2488)
+  $ => A :MLOAD(SP + 2520)
+  B => C
+  $ => B :MLOAD(SP + 2704)
+  $ => A :ADD
+  A :MSTORE(SP + 2480)
+  $ => B :MLOAD(SP + 2576)
+  $ => A :MLOAD(SP + 2528)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2480)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2576)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2480)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2472)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2480)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2472)
+  $ => A :XOR
+  A :MSTORE(SP + 2472)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2480)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2472)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  10538285293956497408n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2504)
+  $ => A :ADD
+  A :MSTORE(SP + 2464)
+  B :MSTORE(SP + 2472)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2464)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2464)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2560)
+  A => C
+  $ => A :MLOAD(SP + 2512)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2464)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2512)
+  B => E
+  $ => B :MLOAD(SP + 2560)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2456)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 28)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2448)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2448)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2448)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2440)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2440)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2448)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2576)
+  $ => B :ADD
+  A :MSTORE(SP + 2440)
+  $ => A :MLOAD(SP + 2472)
+  B => C
+  $ => B :MLOAD(SP + 2656)
+  $ => A :ADD
+  A :MSTORE(SP + 2432)
+  $ => B :MLOAD(SP + 2528)
+  $ => A :MLOAD(SP + 2480)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2432)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2528)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2424)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2424)
+  $ => A :XOR
+  A :MSTORE(SP + 2424)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2424)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  12329834148754620416n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2456)
+  $ => A :ADD
+  A :MSTORE(SP + 2416)
+  B :MSTORE(SP + 2424)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2512)
+  A => C
+  $ => A :MLOAD(SP + 2464)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2416)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2464)
+  B => D
+  $ => B :MLOAD(SP + 2512)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2408)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 32)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2400)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2400)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2400)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2392)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2392)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2400)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2528)
+  $ => B :ADD
+  A :MSTORE(SP + 2392)
+  $ => A :MLOAD(SP + 2424)
+  B => E
+  $ => B :MLOAD(SP + 2608)
+  $ => A :ADD
+  A :MSTORE(SP + 2384)
+  $ => B :MLOAD(SP + 2480)
+  $ => A :MLOAD(SP + 2432)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2384)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2480)
+  $ => CTX :XOR
+  E => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2384)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2376)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2384)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2376)
+  $ => A :XOR
+  A :MSTORE(SP + 2376)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2384)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2376)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  15566598206841159680n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2408)
+  $ => A :ADD
+  A :MSTORE(SP + 2368)
+  B :MSTORE(SP + 2376)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2464)
+  A => C
+  $ => A :MLOAD(SP + 2416)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2368)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2416)
+  B => D
+  $ => B :MLOAD(SP + 2464)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2360)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 36)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2352)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2352)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2352)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2344)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2344)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2352)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2480)
+  $ => B :ADD
+  A :MSTORE(SP + 2344)
+  $ => A :MLOAD(SP + 2376)
+  B => C
+  $ => B :MLOAD(SP + 2560)
+  $ => A :ADD
+  A :MSTORE(SP + 2336)
+  $ => B :MLOAD(SP + 2432)
+  $ => A :MLOAD(SP + 2384)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2336)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2432)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2328)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2328)
+  $ => A :XOR
+  A :MSTORE(SP + 2328)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2328)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  1334009974484893696n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2360)
+  $ => A :ADD
+  A :MSTORE(SP + 2320)
+  B :MSTORE(SP + 2328)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2320)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2320)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2416)
+  A => E
+  $ => A :MLOAD(SP + 2368)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2320)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2368)
+  B => C
+  $ => B :MLOAD(SP + 2416)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 2312)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 40)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2304)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2304)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2304)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2296)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2296)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2304)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2432)
+  $ => B :ADD
+  A :MSTORE(SP + 2296)
+  $ => A :MLOAD(SP + 2328)
+  B => C
+  $ => B :MLOAD(SP + 2512)
+  $ => A :ADD
+  A :MSTORE(SP + 2288)
+  $ => B :MLOAD(SP + 2384)
+  $ => A :MLOAD(SP + 2336)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2288)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2384)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2280)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2280)
+  $ => A :XOR
+  A :MSTORE(SP + 2280)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2280)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  2608012710314508288n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2312)
+  $ => A :ADD
+  A :MSTORE(SP + 2272)
+  B :MSTORE(SP + 2280)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2272)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2272)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2368)
+  A => D
+  $ => A :MLOAD(SP + 2320)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2272)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2320)
+  B => C
+  $ => B :MLOAD(SP + 2368)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  D => A
+  $ => A :ADD
+  A :MSTORE(SP + 2264)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 44)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2256)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2256)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2256)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2248)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2248)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2256)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2384)
+  $ => B :ADD
+  A :MSTORE(SP + 2248)
+  $ => A :MLOAD(SP + 2280)
+  B => E
+  $ => B :MLOAD(SP + 2464)
+  $ => A :ADD
+  A :MSTORE(SP + 2240)
+  $ => B :MLOAD(SP + 2336)
+  $ => A :MLOAD(SP + 2288)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2240)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2336)
+  $ => CTX :XOR
+  E => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2240)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2232)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2240)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2232)
+  $ => A :XOR
+  A :MSTORE(SP + 2232)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2240)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2232)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  6128411469416497152n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2264)
+  $ => A :ADD
+  A :MSTORE(SP + 2224)
+  B :MSTORE(SP + 2232)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2224)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2224)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2320)
+  A => C
+  $ => A :MLOAD(SP + 2272)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2224)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2272)
+  B => D
+  $ => B :MLOAD(SP + 2320)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2216)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 48)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2208)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2208)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2208)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2200)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2200)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2208)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2336)
+  $ => B :ADD
+  A :MSTORE(SP + 2200)
+  $ => A :MLOAD(SP + 2232)
+  B => C
+  $ => B :MLOAD(SP + 2416)
+  $ => A :ADD
+  A :MSTORE(SP + 2192)
+  $ => B :MLOAD(SP + 2288)
+  $ => A :MLOAD(SP + 2240)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2192)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2288)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2184)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2184)
+  $ => A :XOR
+  A :MSTORE(SP + 2184)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2184)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  8268148718696398848n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2216)
+  $ => A :ADD
+  A :MSTORE(SP + 2176)
+  B :MSTORE(SP + 2184)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2272)
+  A => C
+  $ => A :MLOAD(SP + 2224)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2176)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2224)
+  B => E
+  $ => B :MLOAD(SP + 2272)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2168)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 52)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2160)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2160)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2160)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2152)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2152)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2160)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2288)
+  $ => B :ADD
+  A :MSTORE(SP + 2152)
+  $ => A :MLOAD(SP + 2184)
+  B => C
+  $ => B :MLOAD(SP + 2368)
+  $ => A :ADD
+  A :MSTORE(SP + 2144)
+  $ => B :MLOAD(SP + 2240)
+  $ => A :MLOAD(SP + 2192)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2144)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2240)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2144)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2136)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2144)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2136)
+  $ => A :XOR
+  A :MSTORE(SP + 2136)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2144)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2136)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  9286055186164350976n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2168)
+  $ => A :ADD
+  A :MSTORE(SP + 2128)
+  B :MSTORE(SP + 2136)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2224)
+  A => C
+  $ => A :MLOAD(SP + 2176)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2128)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2176)
+  B => D
+  $ => B :MLOAD(SP + 2224)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2120)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 56)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2112)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2112)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2112)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2104)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2104)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2112)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2240)
+  A :MSTORE(SP + 2104)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2136)
+  B => E
+  $ => B :MLOAD(SP + 2320)
+  $ => A :ADD
+  A :MSTORE(SP + 2096)
+  $ => B :MLOAD(SP + 2192)
+  $ => A :MLOAD(SP + 2144)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2096)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2192)
+  $ => CTX :XOR
+  E => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2088)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2088)
+  $ => A :XOR
+  A :MSTORE(SP + 2088)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2088)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  11230858885084479488n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2120)
+  $ => A :ADD
+  A :MSTORE(SP + 2080)
+  B :MSTORE(SP + 2088)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2080)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2080)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2176)
+  A => C
+  $ => A :MLOAD(SP + 2128)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2080)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2128)
+  B => D
+  $ => B :MLOAD(SP + 2176)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 2072)
+  $ => A :MLOAD(SP + 24)
+  $ => B :MLOAD(A)
+  B => A
+  $ => B :MLOAD(SP + 64)
+  $ => CTX :ADD
+  $ => A :MLOAD(CTX + 60)
+  A => CTX
+  103079215104n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  E :MSTORE(SP + 2064)
+  280375465082880n => B
+  $ => B :AND
+  B => A
+  34359738368n => E
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  $ => A :MLOAD(SP + 2064)
+  E => B
+  $ => A :OR
+  A :MSTORE(SP + 2064)
+  34359738368n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  280375465082880n => B
+  $ => A :AND
+  A :MSTORE(SP + 2056)
+  103079215104n => E
+  CTX => A
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2056)
+  $ => B :OR
+  $ => A :MLOAD(SP + 2064)
+  $ => A :OR
+  $ => B :MLOAD(SP + 2192)
+  A :MSTORE(SP + 2056)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2088)
+  B => C
+  $ => B :MLOAD(SP + 2272)
+  $ => A :ADD
+  A :MSTORE(SP + 2048)
+  $ => B :MLOAD(SP + 2144)
+  $ => A :MLOAD(SP + 2096)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2048)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2144)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2048)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2040)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2048)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2040)
+  $ => A :XOR
+  A :MSTORE(SP + 2040)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2048)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2040)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  13951009751228743680n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2072)
+  $ => A :ADD
+  A :MSTORE(SP + 2032)
+  B :MSTORE(SP + 2040)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 2032)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 2032)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2128)
+  A => E
+  $ => A :MLOAD(SP + 2080)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2032)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2080)
+  B => C
+  $ => B :MLOAD(SP + 2128)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 2024)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2728)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2768)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2344)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 2104)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2016)
+  55834574848n => E
+  $ => A :MLOAD(SP + 2104)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2016)
+  $ => A :XOR
+  A :MSTORE(SP + 2016)
+  42949672960n => E
+  $ => A :MLOAD(SP + 2104)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 2016)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2144)
+  A :MSTORE(SP + 2016)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2040)
+  B => C
+  $ => B :MLOAD(SP + 2224)
+  $ => A :ADD
+  A :MSTORE(SP + 2008)
+  $ => B :MLOAD(SP + 2096)
+  $ => A :MLOAD(SP + 2048)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 2008)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2096)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 2008)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 2000)
+  90194313216n => E
+  $ => A :MLOAD(SP + 2008)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2000)
+  $ => A :XOR
+  A :MSTORE(SP + 2000)
+  30064771072n => E
+  $ => A :MLOAD(SP + 2008)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 2000)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  16472876339687325696n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2024)
+  $ => A :ADD
+  A :MSTORE(SP + 1992)
+  B :MSTORE(SP + 2000)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1992)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1992)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2080)
+  A => C
+  $ => A :MLOAD(SP + 2032)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1992)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 2032)
+  B => D
+  $ => B :MLOAD(SP + 2080)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1984)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2680)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2680)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2680)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2728)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2296)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 2056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1976)
+  55834574848n => E
+  $ => A :MLOAD(SP + 2056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1976)
+  $ => A :XOR
+  A :MSTORE(SP + 1976)
+  42949672960n => E
+  $ => A :MLOAD(SP + 2056)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1976)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2096)
+  A :MSTORE(SP + 1976)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 2000)
+  B => C
+  $ => B :MLOAD(SP + 2176)
+  $ => A :ADD
+  A :MSTORE(SP + 1968)
+  $ => B :MLOAD(SP + 2048)
+  $ => A :MLOAD(SP + 2008)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1968)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2048)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1968)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1960)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1968)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1960)
+  $ => A :XOR
+  A :MSTORE(SP + 1960)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1968)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1960)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  17275323861490991104n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1984)
+  $ => A :ADD
+  A :MSTORE(SP + 1952)
+  B :MSTORE(SP + 1960)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1952)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1952)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2032)
+  A => C
+  $ => A :MLOAD(SP + 1992)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1952)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1992)
+  B => E
+  $ => B :MLOAD(SP + 2032)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1944)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2632)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2632)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2632)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2680)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2248)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 2016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1936)
+  55834574848n => E
+  $ => A :MLOAD(SP + 2016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1936)
+  $ => A :XOR
+  A :MSTORE(SP + 1936)
+  42949672960n => E
+  $ => A :MLOAD(SP + 2016)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1936)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2048)
+  A :MSTORE(SP + 1936)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1960)
+  B => C
+  $ => B :MLOAD(SP + 2128)
+  $ => A :ADD
+  A :MSTORE(SP + 1928)
+  $ => B :MLOAD(SP + 2008)
+  $ => A :MLOAD(SP + 1968)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1928)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 2008)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1928)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1920)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1928)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1920)
+  $ => A :XOR
+  A :MSTORE(SP + 1920)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1928)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1920)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  1135362054803161088n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1944)
+  $ => A :ADD
+  A :MSTORE(SP + 1912)
+  B :MSTORE(SP + 1920)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1912)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1912)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1992)
+  A => E
+  $ => A :MLOAD(SP + 1952)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1912)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1952)
+  B => C
+  $ => B :MLOAD(SP + 1992)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1904)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2584)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2584)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2584)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2632)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2200)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1896)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1896)
+  $ => A :XOR
+  A :MSTORE(SP + 1896)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1976)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1896)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2008)
+  A :MSTORE(SP + 1896)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1920)
+  B => C
+  $ => B :MLOAD(SP + 2080)
+  $ => A :ADD
+  A :MSTORE(SP + 1888)
+  $ => B :MLOAD(SP + 1968)
+  $ => A :MLOAD(SP + 1928)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1888)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1968)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1888)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1880)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1888)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1880)
+  $ => A :XOR
+  A :MSTORE(SP + 1880)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1888)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1880)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  2597628982631333888n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1904)
+  $ => A :ADD
+  A :MSTORE(SP + 1872)
+  B :MSTORE(SP + 1880)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1872)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1872)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1952)
+  A => C
+  $ => A :MLOAD(SP + 1912)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1872)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1912)
+  B => D
+  $ => B :MLOAD(SP + 1952)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1864)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2536)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2584)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2152)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1856)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1856)
+  $ => A :XOR
+  A :MSTORE(SP + 1856)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1936)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1856)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1968)
+  A :MSTORE(SP + 1856)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1880)
+  B => C
+  $ => B :MLOAD(SP + 2032)
+  $ => A :ADD
+  A :MSTORE(SP + 1848)
+  $ => B :MLOAD(SP + 1928)
+  $ => A :MLOAD(SP + 1888)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1848)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1928)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1848)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1840)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1848)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1840)
+  $ => A :XOR
+  A :MSTORE(SP + 1840)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1848)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1840)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  3308224256533331968n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1864)
+  $ => A :ADD
+  A :MSTORE(SP + 1832)
+  B :MSTORE(SP + 1840)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1832)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1832)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1912)
+  A => C
+  $ => A :MLOAD(SP + 1872)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1832)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1872)
+  B => E
+  $ => B :MLOAD(SP + 1912)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1824)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2488)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2536)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2104)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1816)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1816)
+  $ => A :XOR
+  A :MSTORE(SP + 1816)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1896)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1816)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1928)
+  A :MSTORE(SP + 1816)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1840)
+  B => C
+  $ => B :MLOAD(SP + 1992)
+  $ => A :ADD
+  A :MSTORE(SP + 1808)
+  $ => B :MLOAD(SP + 1888)
+  $ => A :MLOAD(SP + 1848)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1808)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1888)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1808)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1800)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1808)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1800)
+  $ => A :XOR
+  A :MSTORE(SP + 1800)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1808)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1800)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  5365058921784410112n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1824)
+  $ => A :ADD
+  A :MSTORE(SP + 1792)
+  B :MSTORE(SP + 1800)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1792)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1792)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1872)
+  A => E
+  $ => A :MLOAD(SP + 1832)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1792)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1832)
+  B => C
+  $ => B :MLOAD(SP + 1872)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1784)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2440)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2440)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2440)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2488)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2056)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1776)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1776)
+  $ => A :XOR
+  A :MSTORE(SP + 1776)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1856)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1776)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1888)
+  A :MSTORE(SP + 1776)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1800)
+  B => C
+  $ => B :MLOAD(SP + 1952)
+  $ => A :ADD
+  A :MSTORE(SP + 1768)
+  $ => B :MLOAD(SP + 1848)
+  $ => A :MLOAD(SP + 1808)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1768)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1848)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1768)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1760)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1768)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1760)
+  $ => A :XOR
+  A :MSTORE(SP + 1760)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1768)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1760)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  6679025009748344832n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1784)
+  $ => A :ADD
+  A :MSTORE(SP + 1752)
+  B :MSTORE(SP + 1760)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1752)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1752)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1832)
+  A => C
+  $ => A :MLOAD(SP + 1792)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1752)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1792)
+  B => D
+  $ => B :MLOAD(SP + 1832)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1744)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2392)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2392)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2392)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2440)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 2016)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1736)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1736)
+  $ => A :XOR
+  A :MSTORE(SP + 1736)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1816)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1736)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1848)
+  A :MSTORE(SP + 1736)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1760)
+  B => C
+  $ => B :MLOAD(SP + 1912)
+  $ => A :ADD
+  A :MSTORE(SP + 1728)
+  $ => B :MLOAD(SP + 1808)
+  $ => A :MLOAD(SP + 1768)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1728)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1808)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1720)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1720)
+  $ => A :XOR
+  A :MSTORE(SP + 1720)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1720)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  8573033835560697856n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1744)
+  $ => A :ADD
+  A :MSTORE(SP + 1712)
+  B :MSTORE(SP + 1720)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1712)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1712)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1792)
+  A => C
+  $ => A :MLOAD(SP + 1752)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1712)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1752)
+  B => E
+  $ => B :MLOAD(SP + 1792)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1704)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2344)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2344)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2344)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2392)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1976)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1696)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1696)
+  $ => A :XOR
+  A :MSTORE(SP + 1696)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1776)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1696)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1808)
+  A :MSTORE(SP + 1696)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1720)
+  B => C
+  $ => B :MLOAD(SP + 1872)
+  $ => A :ADD
+  A :MSTORE(SP + 1688)
+  $ => B :MLOAD(SP + 1768)
+  $ => A :MLOAD(SP + 1728)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1688)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1768)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1688)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1680)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1688)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1680)
+  $ => A :XOR
+  A :MSTORE(SP + 1680)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1688)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1680)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  10970295154950275072n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1704)
+  $ => A :ADD
+  A :MSTORE(SP + 1672)
+  B :MSTORE(SP + 1680)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1752)
+  A => E
+  $ => A :MLOAD(SP + 1712)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1672)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1712)
+  B => C
+  $ => B :MLOAD(SP + 1752)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1664)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2296)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2344)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1936)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1656)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1656)
+  $ => A :XOR
+  A :MSTORE(SP + 1656)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1736)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1656)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1768)
+  A :MSTORE(SP + 1656)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1680)
+  B => C
+  $ => B :MLOAD(SP + 1832)
+  $ => A :ADD
+  A :MSTORE(SP + 1648)
+  $ => B :MLOAD(SP + 1728)
+  $ => A :MLOAD(SP + 1688)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1648)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1728)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1648)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1640)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1648)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1640)
+  $ => A :XOR
+  A :MSTORE(SP + 1640)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1648)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1640)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  12119686243684450304n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1664)
+  $ => A :ADD
+  A :MSTORE(SP + 1632)
+  B :MSTORE(SP + 1640)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1632)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1632)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1712)
+  A => C
+  $ => A :MLOAD(SP + 1672)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1632)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1672)
+  B => D
+  $ => B :MLOAD(SP + 1712)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1624)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2248)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2296)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1896)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1696)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1616)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1696)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1616)
+  $ => A :XOR
+  A :MSTORE(SP + 1616)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1696)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1616)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1728)
+  A :MSTORE(SP + 1616)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1640)
+  B => C
+  $ => B :MLOAD(SP + 1792)
+  $ => A :ADD
+  A :MSTORE(SP + 1608)
+  $ => B :MLOAD(SP + 1688)
+  $ => A :MLOAD(SP + 1648)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1608)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1688)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1600)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1600)
+  $ => A :XOR
+  A :MSTORE(SP + 1600)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1600)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  12683024715552391168n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1624)
+  $ => A :ADD
+  A :MSTORE(SP + 1592)
+  B :MSTORE(SP + 1600)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1592)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1592)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1672)
+  A => C
+  $ => A :MLOAD(SP + 1632)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1592)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1632)
+  B => E
+  $ => B :MLOAD(SP + 1672)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1584)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2200)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2200)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2200)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2248)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1856)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1576)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1576)
+  $ => A :XOR
+  A :MSTORE(SP + 1576)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1656)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1576)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1688)
+  A :MSTORE(SP + 1576)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1600)
+  B => C
+  $ => B :MLOAD(SP + 1752)
+  $ => A :ADD
+  A :MSTORE(SP + 1568)
+  $ => B :MLOAD(SP + 1648)
+  $ => A :MLOAD(SP + 1608)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1568)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1648)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1568)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1560)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1568)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1560)
+  $ => A :XOR
+  A :MSTORE(SP + 1560)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1568)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1560)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  13788192226846703616n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1584)
+  $ => A :ADD
+  A :MSTORE(SP + 1552)
+  B :MSTORE(SP + 1560)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1552)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1552)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1632)
+  A => E
+  $ => A :MLOAD(SP + 1592)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1552)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1592)
+  B => C
+  $ => B :MLOAD(SP + 1632)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1544)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2152)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2152)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2152)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2200)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1816)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1616)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1536)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1616)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1536)
+  $ => A :XOR
+  A :MSTORE(SP + 1536)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1616)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1536)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1648)
+  A :MSTORE(SP + 1536)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1560)
+  B => C
+  $ => B :MLOAD(SP + 1712)
+  $ => A :ADD
+  A :MSTORE(SP + 1528)
+  $ => B :MLOAD(SP + 1608)
+  $ => A :MLOAD(SP + 1568)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1528)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1608)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1520)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1520)
+  $ => A :XOR
+  A :MSTORE(SP + 1520)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1520)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  14330467152597876736n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1544)
+  $ => A :ADD
+  A :MSTORE(SP + 1512)
+  B :MSTORE(SP + 1520)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1512)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1512)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1592)
+  A => C
+  $ => A :MLOAD(SP + 1552)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1512)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1552)
+  B => D
+  $ => B :MLOAD(SP + 1592)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1504)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2104)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2104)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2104)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2152)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1776)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1496)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1496)
+  $ => A :XOR
+  A :MSTORE(SP + 1496)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1576)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1496)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1608)
+  A :MSTORE(SP + 1496)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1520)
+  B => C
+  $ => B :MLOAD(SP + 1672)
+  $ => A :ADD
+  A :MSTORE(SP + 1488)
+  $ => B :MLOAD(SP + 1568)
+  $ => A :MLOAD(SP + 1528)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1488)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1568)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1480)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1480)
+  $ => A :XOR
+  A :MSTORE(SP + 1480)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1480)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  15395433585318035456n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1504)
+  $ => A :ADD
+  A :MSTORE(SP + 1472)
+  B :MSTORE(SP + 1480)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1472)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1472)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1552)
+  A => C
+  $ => A :MLOAD(SP + 1512)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1472)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1512)
+  B => E
+  $ => B :MLOAD(SP + 1552)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1464)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2056)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2104)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1736)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1456)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1456)
+  $ => A :XOR
+  A :MSTORE(SP + 1456)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1536)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1456)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1568)
+  A :MSTORE(SP + 1456)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1480)
+  B => C
+  $ => B :MLOAD(SP + 1632)
+  $ => A :ADD
+  A :MSTORE(SP + 1448)
+  $ => B :MLOAD(SP + 1528)
+  $ => A :MLOAD(SP + 1488)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1448)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1528)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1448)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1440)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1448)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1440)
+  $ => A :XOR
+  A :MSTORE(SP + 1440)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1448)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1440)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  489312709066620928n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1464)
+  $ => A :ADD
+  A :MSTORE(SP + 1432)
+  B :MSTORE(SP + 1440)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1512)
+  A => E
+  $ => A :MLOAD(SP + 1472)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1432)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1472)
+  B => C
+  $ => B :MLOAD(SP + 1512)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1424)
+  107374182400n => E
+  $ => A :MLOAD(SP + 2016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 2016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 2016)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2056)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1696)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1496)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1416)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1496)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1416)
+  $ => A :XOR
+  A :MSTORE(SP + 1416)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1496)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1416)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1528)
+  A :MSTORE(SP + 1416)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1440)
+  B => C
+  $ => B :MLOAD(SP + 1592)
+  $ => A :ADD
+  A :MSTORE(SP + 1408)
+  $ => B :MLOAD(SP + 1488)
+  $ => A :MLOAD(SP + 1448)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1408)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1488)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1408)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1400)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1408)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1400)
+  $ => A :XOR
+  A :MSTORE(SP + 1400)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1408)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1400)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  1452737877162065920n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1424)
+  $ => A :ADD
+  A :MSTORE(SP + 1392)
+  B :MSTORE(SP + 1400)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1392)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1392)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1472)
+  A => C
+  $ => A :MLOAD(SP + 1432)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1392)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1432)
+  B => D
+  $ => B :MLOAD(SP + 1472)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1384)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1976)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 2016)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1656)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1456)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1376)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1456)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1376)
+  $ => A :XOR
+  A :MSTORE(SP + 1376)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1456)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1376)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1488)
+  A :MSTORE(SP + 1376)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1400)
+  B => C
+  $ => B :MLOAD(SP + 1552)
+  $ => A :ADD
+  A :MSTORE(SP + 1368)
+  $ => B :MLOAD(SP + 1448)
+  $ => A :MLOAD(SP + 1408)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1368)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1448)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1360)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1360)
+  $ => A :XOR
+  A :MSTORE(SP + 1360)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1360)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  2861767654564167680n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1384)
+  $ => A :ADD
+  A :MSTORE(SP + 1352)
+  B :MSTORE(SP + 1360)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1352)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1352)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1432)
+  A => C
+  $ => A :MLOAD(SP + 1392)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1352)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1392)
+  B => E
+  $ => B :MLOAD(SP + 1432)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1344)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1936)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1976)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1616)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1336)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1336)
+  $ => A :XOR
+  A :MSTORE(SP + 1336)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1416)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1336)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1448)
+  A :MSTORE(SP + 1336)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1360)
+  B => C
+  $ => B :MLOAD(SP + 1512)
+  $ => A :ADD
+  A :MSTORE(SP + 1328)
+  $ => B :MLOAD(SP + 1408)
+  $ => A :MLOAD(SP + 1368)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1328)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1408)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1328)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1320)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1328)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1320)
+  $ => A :XOR
+  A :MSTORE(SP + 1320)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1328)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1320)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  3322285674517757952n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1344)
+  $ => A :ADD
+  A :MSTORE(SP + 1312)
+  B :MSTORE(SP + 1320)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1312)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1312)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1392)
+  A => E
+  $ => A :MLOAD(SP + 1352)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1312)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1352)
+  B => C
+  $ => B :MLOAD(SP + 1392)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1304)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1896)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1936)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1576)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1376)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1296)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1376)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1296)
+  $ => A :XOR
+  A :MSTORE(SP + 1296)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1376)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1296)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1408)
+  A :MSTORE(SP + 1296)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1320)
+  B => C
+  $ => B :MLOAD(SP + 1472)
+  $ => A :ADD
+  A :MSTORE(SP + 1288)
+  $ => B :MLOAD(SP + 1368)
+  $ => A :MLOAD(SP + 1328)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1288)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1368)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1280)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1280)
+  $ => A :XOR
+  A :MSTORE(SP + 1280)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1280)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  5560940568994906112n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1304)
+  $ => A :ADD
+  A :MSTORE(SP + 1272)
+  B :MSTORE(SP + 1280)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1272)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1272)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1352)
+  A => C
+  $ => A :MLOAD(SP + 1312)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1272)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1312)
+  B => D
+  $ => B :MLOAD(SP + 1352)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1264)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1856)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1896)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1536)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1256)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1256)
+  $ => A :XOR
+  A :MSTORE(SP + 1256)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1336)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1256)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1368)
+  A :MSTORE(SP + 1256)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1280)
+  B => C
+  $ => B :MLOAD(SP + 1432)
+  $ => A :ADD
+  A :MSTORE(SP + 1248)
+  $ => B :MLOAD(SP + 1328)
+  $ => A :MLOAD(SP + 1288)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1248)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1328)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1240)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1240)
+  $ => A :XOR
+  A :MSTORE(SP + 1240)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1240)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  5996557279099355136n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1264)
+  $ => A :ADD
+  A :MSTORE(SP + 1232)
+  B :MSTORE(SP + 1240)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1232)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1232)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1312)
+  A => C
+  $ => A :MLOAD(SP + 1272)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1232)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1272)
+  B => E
+  $ => B :MLOAD(SP + 1312)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1224)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1816)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1856)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1496)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1216)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1216)
+  $ => A :XOR
+  A :MSTORE(SP + 1216)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1296)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1216)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1328)
+  A :MSTORE(SP + 1216)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1240)
+  B => C
+  $ => B :MLOAD(SP + 1392)
+  $ => A :ADD
+  A :MSTORE(SP + 1208)
+  $ => B :MLOAD(SP + 1288)
+  $ => A :MLOAD(SP + 1248)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1208)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1288)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1208)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1200)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1208)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1200)
+  $ => A :XOR
+  A :MSTORE(SP + 1200)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1208)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1200)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  7280758552212275200n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1224)
+  $ => A :ADD
+  A :MSTORE(SP + 1192)
+  B :MSTORE(SP + 1200)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1272)
+  A => E
+  $ => A :MLOAD(SP + 1232)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1192)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1232)
+  B => C
+  $ => B :MLOAD(SP + 1272)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1184)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1776)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1816)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1456)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1256)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1176)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1256)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1176)
+  $ => A :XOR
+  A :MSTORE(SP + 1176)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1256)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1176)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1288)
+  A :MSTORE(SP + 1176)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1200)
+  B => C
+  $ => B :MLOAD(SP + 1352)
+  $ => A :ADD
+  A :MSTORE(SP + 1168)
+  $ => B :MLOAD(SP + 1248)
+  $ => A :MLOAD(SP + 1208)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1168)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1248)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1168)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1160)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1168)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1160)
+  $ => A :XOR
+  A :MSTORE(SP + 1160)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1168)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1160)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  8532644242281988096n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1184)
+  $ => A :ADD
+  A :MSTORE(SP + 1152)
+  B :MSTORE(SP + 1160)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1152)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1152)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1232)
+  A => C
+  $ => A :MLOAD(SP + 1192)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1152)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1192)
+  B => D
+  $ => B :MLOAD(SP + 1232)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1144)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1736)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1776)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1416)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1216)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1136)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1216)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1136)
+  $ => A :XOR
+  A :MSTORE(SP + 1136)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1216)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1136)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1248)
+  A :MSTORE(SP + 1136)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1160)
+  B => C
+  $ => B :MLOAD(SP + 1312)
+  $ => A :ADD
+  A :MSTORE(SP + 1128)
+  $ => B :MLOAD(SP + 1208)
+  $ => A :MLOAD(SP + 1168)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1128)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1208)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1120)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1120)
+  $ => A :XOR
+  A :MSTORE(SP + 1120)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1128)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1120)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  9350256975780249600n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1144)
+  $ => A :ADD
+  A :MSTORE(SP + 1112)
+  B :MSTORE(SP + 1120)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1112)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1112)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1192)
+  A => C
+  $ => A :MLOAD(SP + 1152)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1112)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1152)
+  B => E
+  $ => B :MLOAD(SP + 1192)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1104)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1696)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1696)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1696)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1736)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1376)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1096)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1096)
+  $ => A :XOR
+  A :MSTORE(SP + 1096)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1176)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1096)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1208)
+  A :MSTORE(SP + 1096)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1120)
+  B => C
+  $ => B :MLOAD(SP + 1272)
+  $ => A :ADD
+  A :MSTORE(SP + 1088)
+  $ => B :MLOAD(SP + 1168)
+  $ => A :MLOAD(SP + 1128)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1088)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1168)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1088)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1080)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1088)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1080)
+  $ => A :XOR
+  A :MSTORE(SP + 1080)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1088)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1080)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  10552545826624765952n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1104)
+  $ => A :ADD
+  A :MSTORE(SP + 1072)
+  B :MSTORE(SP + 1080)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1072)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1072)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1152)
+  A => E
+  $ => A :MLOAD(SP + 1112)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1072)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1112)
+  B => C
+  $ => B :MLOAD(SP + 1152)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 1064)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1656)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1696)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1336)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1136)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1056)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1136)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1056)
+  $ => A :XOR
+  A :MSTORE(SP + 1056)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1136)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1056)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1168)
+  A :MSTORE(SP + 1056)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1080)
+  B => C
+  $ => B :MLOAD(SP + 1232)
+  $ => A :ADD
+  A :MSTORE(SP + 1048)
+  $ => B :MLOAD(SP + 1128)
+  $ => A :MLOAD(SP + 1088)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1048)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1128)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1048)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1040)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1048)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1040)
+  $ => A :XOR
+  A :MSTORE(SP + 1040)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1048)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1040)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  11727347732883439616n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1064)
+  $ => A :ADD
+  A :MSTORE(SP + 1032)
+  B :MSTORE(SP + 1040)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 1032)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 1032)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1112)
+  A => C
+  $ => A :MLOAD(SP + 1072)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1032)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1072)
+  B => D
+  $ => B :MLOAD(SP + 1112)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 1024)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1616)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1616)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1616)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1656)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1296)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1016)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1016)
+  $ => A :XOR
+  A :MSTORE(SP + 1016)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1096)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 1016)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1128)
+  A :MSTORE(SP + 1016)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1040)
+  B => C
+  $ => B :MLOAD(SP + 1192)
+  $ => A :ADD
+  A :MSTORE(SP + 1008)
+  $ => B :MLOAD(SP + 1088)
+  $ => A :MLOAD(SP + 1048)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 1008)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1088)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 1008)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 1000)
+  90194313216n => E
+  $ => A :MLOAD(SP + 1008)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1000)
+  $ => A :XOR
+  A :MSTORE(SP + 1000)
+  30064771072n => E
+  $ => A :MLOAD(SP + 1008)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 1000)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  12113106620074950656n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1024)
+  $ => A :ADD
+  A :MSTORE(SP + 992)
+  B :MSTORE(SP + 1000)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 992)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 992)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1072)
+  A => C
+  $ => A :MLOAD(SP + 1032)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 992)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 1032)
+  B => E
+  $ => B :MLOAD(SP + 1072)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 984)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1576)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1616)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1256)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 976)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 976)
+  $ => A :XOR
+  A :MSTORE(SP + 976)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1056)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 976)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1088)
+  A :MSTORE(SP + 976)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 1000)
+  B => C
+  $ => B :MLOAD(SP + 1152)
+  $ => A :ADD
+  A :MSTORE(SP + 968)
+  $ => B :MLOAD(SP + 1048)
+  $ => A :MLOAD(SP + 1008)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 968)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1048)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 968)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 960)
+  90194313216n => E
+  $ => A :MLOAD(SP + 968)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 960)
+  $ => A :XOR
+  A :MSTORE(SP + 960)
+  30064771072n => E
+  $ => A :MLOAD(SP + 968)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 960)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  14000437179763916800n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 984)
+  $ => A :ADD
+  A :MSTORE(SP + 952)
+  B :MSTORE(SP + 960)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 952)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 952)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1032)
+  A => E
+  $ => A :MLOAD(SP + 992)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 952)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 992)
+  B => C
+  $ => B :MLOAD(SP + 1032)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 944)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1536)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1576)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1216)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 1016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 936)
+  55834574848n => E
+  $ => A :MLOAD(SP + 1016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 936)
+  $ => A :XOR
+  A :MSTORE(SP + 936)
+  42949672960n => E
+  $ => A :MLOAD(SP + 1016)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 936)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1048)
+  A :MSTORE(SP + 936)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 960)
+  B => C
+  $ => B :MLOAD(SP + 1112)
+  $ => A :ADD
+  A :MSTORE(SP + 928)
+  $ => B :MLOAD(SP + 1008)
+  $ => A :MLOAD(SP + 968)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 928)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 1008)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 928)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 920)
+  90194313216n => E
+  $ => A :MLOAD(SP + 928)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 920)
+  $ => A :XOR
+  A :MSTORE(SP + 920)
+  30064771072n => E
+  $ => A :MLOAD(SP + 928)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 920)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  14369950271553929216n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 944)
+  $ => A :ADD
+  A :MSTORE(SP + 912)
+  B :MSTORE(SP + 920)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 912)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 912)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 992)
+  A => C
+  $ => A :MLOAD(SP + 952)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 912)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 952)
+  B => D
+  $ => B :MLOAD(SP + 992)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 904)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1496)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1496)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1496)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1536)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1176)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 896)
+  55834574848n => E
+  $ => A :MLOAD(SP + 976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 896)
+  $ => A :XOR
+  A :MSTORE(SP + 896)
+  42949672960n => E
+  $ => A :MLOAD(SP + 976)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 896)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1008)
+  A :MSTORE(SP + 896)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 920)
+  B => C
+  $ => B :MLOAD(SP + 1072)
+  $ => A :ADD
+  A :MSTORE(SP + 888)
+  $ => B :MLOAD(SP + 968)
+  $ => A :MLOAD(SP + 928)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 888)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 968)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 888)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 880)
+  90194313216n => E
+  $ => A :MLOAD(SP + 888)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 880)
+  $ => A :XOR
+  A :MSTORE(SP + 880)
+  30064771072n => E
+  $ => A :MLOAD(SP + 888)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 880)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  15101387694598520832n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 904)
+  $ => A :ADD
+  A :MSTORE(SP + 872)
+  B :MSTORE(SP + 880)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 872)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 872)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 952)
+  A => C
+  $ => A :MLOAD(SP + 912)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 872)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 912)
+  B => E
+  $ => B :MLOAD(SP + 952)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 864)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1456)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1456)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1456)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1496)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1136)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 856)
+  55834574848n => E
+  $ => A :MLOAD(SP + 936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 856)
+  $ => A :XOR
+  A :MSTORE(SP + 856)
+  42949672960n => E
+  $ => A :MLOAD(SP + 936)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 856)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 968)
+  A :MSTORE(SP + 856)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 880)
+  B => C
+  $ => B :MLOAD(SP + 1032)
+  $ => A :ADD
+  A :MSTORE(SP + 848)
+  $ => B :MLOAD(SP + 928)
+  $ => A :MLOAD(SP + 888)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 848)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 928)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 848)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 840)
+  90194313216n => E
+  $ => A :MLOAD(SP + 848)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 840)
+  $ => A :XOR
+  A :MSTORE(SP + 840)
+  30064771072n => E
+  $ => A :MLOAD(SP + 848)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 840)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  15463397547241897984n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 864)
+  $ => A :ADD
+  A :MSTORE(SP + 832)
+  B :MSTORE(SP + 840)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 832)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 832)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 912)
+  A => E
+  $ => A :MLOAD(SP + 872)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 832)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 872)
+  B => C
+  $ => B :MLOAD(SP + 912)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 824)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1416)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1456)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1096)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 816)
+  55834574848n => E
+  $ => A :MLOAD(SP + 896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 816)
+  $ => A :XOR
+  A :MSTORE(SP + 816)
+  42949672960n => E
+  $ => A :MLOAD(SP + 896)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 816)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 928)
+  A :MSTORE(SP + 816)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 840)
+  B => C
+  $ => B :MLOAD(SP + 992)
+  $ => A :ADD
+  A :MSTORE(SP + 808)
+  $ => B :MLOAD(SP + 888)
+  $ => A :MLOAD(SP + 848)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 808)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 888)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 808)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 800)
+  90194313216n => E
+  $ => A :MLOAD(SP + 808)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 800)
+  $ => A :XOR
+  A :MSTORE(SP + 800)
+  30064771072n => E
+  $ => A :MLOAD(SP + 808)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 800)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  17586052440275288064n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 824)
+  $ => A :ADD
+  A :MSTORE(SP + 792)
+  B :MSTORE(SP + 800)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 792)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 792)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 872)
+  A => C
+  $ => A :MLOAD(SP + 832)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 792)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 832)
+  B => D
+  $ => B :MLOAD(SP + 872)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 784)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1376)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1376)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1376)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1416)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1056)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 776)
+  55834574848n => E
+  $ => A :MLOAD(SP + 856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 776)
+  $ => A :XOR
+  A :MSTORE(SP + 776)
+  42949672960n => E
+  $ => A :MLOAD(SP + 856)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 776)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 888)
+  A :MSTORE(SP + 776)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 800)
+  B => C
+  $ => B :MLOAD(SP + 952)
+  $ => A :ADD
+  A :MSTORE(SP + 768)
+  $ => B :MLOAD(SP + 848)
+  $ => A :MLOAD(SP + 808)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 768)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 848)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 768)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 760)
+  90194313216n => E
+  $ => A :MLOAD(SP + 768)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 760)
+  $ => A :XOR
+  A :MSTORE(SP + 760)
+  30064771072n => E
+  $ => A :MLOAD(SP + 768)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 760)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  1182934255034957824n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 784)
+  $ => A :ADD
+  A :MSTORE(SP + 752)
+  B :MSTORE(SP + 760)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 752)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 752)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 832)
+  A => C
+  $ => A :MLOAD(SP + 792)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 752)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 792)
+  B => E
+  $ => B :MLOAD(SP + 832)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 744)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1336)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1376)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 1016)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 736)
+  55834574848n => E
+  $ => A :MLOAD(SP + 816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 736)
+  $ => A :XOR
+  A :MSTORE(SP + 736)
+  42949672960n => E
+  $ => A :MLOAD(SP + 816)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 736)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 848)
+  A :MSTORE(SP + 736)
+  $ => B :ADD
+  $ => A :MLOAD(SP + 760)
+  B => C
+  $ => B :MLOAD(SP + 912)
+  $ => A :ADD
+  A :MSTORE(SP + 728)
+  $ => B :MLOAD(SP + 808)
+  $ => A :MLOAD(SP + 768)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 728)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 808)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 720)
+  90194313216n => E
+  $ => A :MLOAD(SP + 728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 720)
+  $ => A :XOR
+  A :MSTORE(SP + 720)
+  30064771072n => E
+  $ => A :MLOAD(SP + 728)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 720)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  1847814047362187264n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 744)
+  $ => A :ADD
+  A :MSTORE(SP + 712)
+  B :MSTORE(SP + 720)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 712)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 712)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 792)
+  A => E
+  $ => A :MLOAD(SP + 752)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 712)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 752)
+  B => C
+  $ => B :MLOAD(SP + 792)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 704)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1296)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1336)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 976)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 696)
+  55834574848n => E
+  $ => A :MLOAD(SP + 776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 696)
+  $ => A :XOR
+  A :MSTORE(SP + 696)
+  42949672960n => E
+  $ => A :MLOAD(SP + 776)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 696)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 808)
+  $ => B :ADD
+  A :MSTORE(SP + 696)
+  $ => A :MLOAD(SP + 720)
+  B => C
+  $ => B :MLOAD(SP + 872)
+  $ => A :ADD
+  A :MSTORE(SP + 688)
+  $ => B :MLOAD(SP + 768)
+  $ => A :MLOAD(SP + 728)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 688)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 768)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 688)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 680)
+  90194313216n => E
+  $ => A :MLOAD(SP + 688)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 680)
+  $ => A :XOR
+  A :MSTORE(SP + 680)
+  30064771072n => E
+  $ => A :MLOAD(SP + 688)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 680)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  2177327726472462336n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 704)
+  $ => A :ADD
+  A :MSTORE(SP + 672)
+  B :MSTORE(SP + 680)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 672)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 752)
+  A => C
+  $ => A :MLOAD(SP + 712)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 672)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 712)
+  B => D
+  $ => B :MLOAD(SP + 752)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 664)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1256)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1256)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1256)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1296)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 936)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 656)
+  55834574848n => E
+  $ => A :MLOAD(SP + 736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 656)
+  $ => A :XOR
+  A :MSTORE(SP + 656)
+  42949672960n => E
+  $ => A :MLOAD(SP + 736)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 656)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 768)
+  $ => B :ADD
+  A :MSTORE(SP + 656)
+  $ => A :MLOAD(SP + 680)
+  B => C
+  $ => B :MLOAD(SP + 832)
+  $ => A :ADD
+  A :MSTORE(SP + 648)
+  $ => B :MLOAD(SP + 728)
+  $ => A :MLOAD(SP + 688)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 648)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 728)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 648)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 640)
+  90194313216n => E
+  $ => A :MLOAD(SP + 648)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 640)
+  $ => A :XOR
+  A :MSTORE(SP + 640)
+  30064771072n => E
+  $ => A :MLOAD(SP + 648)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 640)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  2830643534103576576n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 664)
+  $ => A :ADD
+  A :MSTORE(SP + 632)
+  B :MSTORE(SP + 640)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 632)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 632)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 712)
+  A => C
+  $ => A :MLOAD(SP + 672)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 632)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 672)
+  B => E
+  $ => B :MLOAD(SP + 712)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 624)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1216)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1216)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1216)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1256)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 896)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 696)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 616)
+  55834574848n => E
+  $ => A :MLOAD(SP + 696)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 616)
+  $ => A :XOR
+  A :MSTORE(SP + 616)
+  42949672960n => E
+  $ => A :MLOAD(SP + 696)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 616)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 728)
+  $ => B :ADD
+  A :MSTORE(SP + 616)
+  $ => A :MLOAD(SP + 640)
+  B => C
+  $ => B :MLOAD(SP + 792)
+  $ => A :ADD
+  A :MSTORE(SP + 608)
+  $ => B :MLOAD(SP + 688)
+  $ => A :MLOAD(SP + 648)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 608)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 688)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 600)
+  90194313216n => E
+  $ => A :MLOAD(SP + 608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 600)
+  $ => A :XOR
+  A :MSTORE(SP + 600)
+  30064771072n => E
+  $ => A :MLOAD(SP + 608)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 600)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  3796741971448430592n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 624)
+  $ => A :ADD
+  A :MSTORE(SP + 592)
+  B :MSTORE(SP + 600)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 592)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 592)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 672)
+  A => E
+  $ => A :MLOAD(SP + 632)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 592)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 632)
+  B => C
+  $ => B :MLOAD(SP + 672)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 584)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1176)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1216)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 856)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 576)
+  55834574848n => E
+  $ => A :MLOAD(SP + 656)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 576)
+  $ => A :XOR
+  A :MSTORE(SP + 576)
+  42949672960n => E
+  $ => A :MLOAD(SP + 656)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 576)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 688)
+  $ => B :ADD
+  A :MSTORE(SP + 576)
+  $ => A :MLOAD(SP + 600)
+  B => C
+  $ => B :MLOAD(SP + 752)
+  $ => A :ADD
+  A :MSTORE(SP + 568)
+  $ => B :MLOAD(SP + 648)
+  $ => A :MLOAD(SP + 608)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 568)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 648)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 568)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 560)
+  90194313216n => E
+  $ => A :MLOAD(SP + 568)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 560)
+  $ => A :XOR
+  A :MSTORE(SP + 560)
+  30064771072n => E
+  $ => A :MLOAD(SP + 568)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 560)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  4115178122448470016n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 584)
+  $ => A :ADD
+  A :MSTORE(SP + 552)
+  B :MSTORE(SP + 560)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 552)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 552)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 632)
+  A => C
+  $ => A :MLOAD(SP + 592)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 552)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 592)
+  B => D
+  $ => B :MLOAD(SP + 632)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 544)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1136)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1136)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1136)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1176)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 816)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 616)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 536)
+  55834574848n => E
+  $ => A :MLOAD(SP + 616)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 536)
+  $ => A :XOR
+  A :MSTORE(SP + 536)
+  42949672960n => E
+  $ => A :MLOAD(SP + 616)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 536)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 648)
+  $ => B :ADD
+  A :MSTORE(SP + 536)
+  $ => A :MLOAD(SP + 560)
+  B => C
+  $ => B :MLOAD(SP + 712)
+  $ => A :ADD
+  A :MSTORE(SP + 528)
+  $ => B :MLOAD(SP + 608)
+  $ => A :MLOAD(SP + 568)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 528)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 608)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 520)
+  90194313216n => E
+  $ => A :MLOAD(SP + 528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 520)
+  $ => A :XOR
+  A :MSTORE(SP + 520)
+  30064771072n => E
+  $ => A :MLOAD(SP + 528)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 520)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  5681478164732182528n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 544)
+  $ => A :ADD
+  A :MSTORE(SP + 512)
+  B :MSTORE(SP + 520)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 512)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 512)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 592)
+  A => C
+  $ => A :MLOAD(SP + 552)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 512)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 552)
+  B => E
+  $ => B :MLOAD(SP + 592)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 504)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1096)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1096)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1136)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 776)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 496)
+  55834574848n => E
+  $ => A :MLOAD(SP + 576)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 496)
+  $ => A :XOR
+  A :MSTORE(SP + 496)
+  42949672960n => E
+  $ => A :MLOAD(SP + 576)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 496)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 608)
+  $ => B :ADD
+  A :MSTORE(SP + 496)
+  $ => A :MLOAD(SP + 520)
+  B => C
+  $ => B :MLOAD(SP + 672)
+  $ => A :ADD
+  A :MSTORE(SP + 488)
+  $ => B :MLOAD(SP + 568)
+  $ => A :MLOAD(SP + 528)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 488)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 568)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 480)
+  90194313216n => E
+  $ => A :MLOAD(SP + 488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 480)
+  $ => A :XOR
+  A :MSTORE(SP + 480)
+  30064771072n => E
+  $ => A :MLOAD(SP + 488)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 480)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  6601373594469531648n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 504)
+  $ => A :ADD
+  A :MSTORE(SP + 472)
+  B :MSTORE(SP + 480)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 472)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 472)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 552)
+  A => E
+  $ => A :MLOAD(SP + 512)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 472)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 512)
+  B => C
+  $ => B :MLOAD(SP + 552)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 464)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1056)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1056)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1096)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 736)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 456)
+  55834574848n => E
+  $ => A :MLOAD(SP + 536)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 456)
+  $ => A :XOR
+  A :MSTORE(SP + 456)
+  42949672960n => E
+  $ => A :MLOAD(SP + 536)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 456)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 568)
+  $ => B :ADD
+  A :MSTORE(SP + 456)
+  $ => A :MLOAD(SP + 480)
+  B => C
+  $ => B :MLOAD(SP + 632)
+  $ => A :ADD
+  A :MSTORE(SP + 448)
+  $ => B :MLOAD(SP + 528)
+  $ => A :MLOAD(SP + 488)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 448)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 528)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 448)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 440)
+  90194313216n => E
+  $ => A :MLOAD(SP + 448)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 440)
+  $ => A :XOR
+  A :MSTORE(SP + 440)
+  30064771072n => E
+  $ => A :MLOAD(SP + 448)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 440)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  7507060718340931584n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 464)
+  $ => A :ADD
+  A :MSTORE(SP + 432)
+  B :MSTORE(SP + 440)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 432)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 512)
+  A => C
+  $ => A :MLOAD(SP + 472)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 432)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 472)
+  B => D
+  $ => B :MLOAD(SP + 512)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 424)
+  107374182400n => E
+  $ => A :MLOAD(SP + 1016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 1016)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 1016)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1056)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 696)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 496)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 416)
+  55834574848n => E
+  $ => A :MLOAD(SP + 496)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 416)
+  $ => A :XOR
+  A :MSTORE(SP + 416)
+  42949672960n => E
+  $ => A :MLOAD(SP + 496)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 416)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 528)
+  $ => B :ADD
+  A :MSTORE(SP + 416)
+  $ => A :MLOAD(SP + 440)
+  B => C
+  $ => B :MLOAD(SP + 592)
+  $ => A :ADD
+  A :MSTORE(SP + 408)
+  $ => B :MLOAD(SP + 488)
+  $ => A :MLOAD(SP + 448)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 408)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 488)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 408)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 400)
+  90194313216n => E
+  $ => A :MLOAD(SP + 408)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 400)
+  $ => A :XOR
+  A :MSTORE(SP + 400)
+  30064771072n => E
+  $ => A :MLOAD(SP + 408)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 400)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  8399075788783091712n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 424)
+  $ => A :ADD
+  A :MSTORE(SP + 392)
+  B :MSTORE(SP + 400)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 392)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 392)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 472)
+  A => C
+  $ => A :MLOAD(SP + 432)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 392)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 432)
+  B => E
+  $ => B :MLOAD(SP + 472)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 384)
+  107374182400n => E
+  $ => A :MLOAD(SP + 976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 976)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 976)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 1016)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 656)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 456)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 376)
+  55834574848n => E
+  $ => A :MLOAD(SP + 456)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 376)
+  $ => A :XOR
+  A :MSTORE(SP + 376)
+  42949672960n => E
+  $ => A :MLOAD(SP + 456)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 376)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 488)
+  $ => B :ADD
+  A :MSTORE(SP + 376)
+  $ => A :MLOAD(SP + 400)
+  B => C
+  $ => B :MLOAD(SP + 552)
+  $ => A :ADD
+  A :MSTORE(SP + 368)
+  $ => B :MLOAD(SP + 448)
+  $ => A :MLOAD(SP + 408)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 368)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 448)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 360)
+  90194313216n => E
+  $ => A :MLOAD(SP + 368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 360)
+  $ => A :XOR
+  A :MSTORE(SP + 360)
+  30064771072n => E
+  $ => A :MLOAD(SP + 368)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 360)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  8693463984101130240n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 384)
+  $ => A :ADD
+  A :MSTORE(SP + 352)
+  B :MSTORE(SP + 360)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 352)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 352)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 432)
+  A => E
+  $ => A :MLOAD(SP + 392)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 352)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 392)
+  B => C
+  $ => B :MLOAD(SP + 432)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 344)
+  107374182400n => E
+  $ => A :MLOAD(SP + 936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 936)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 936)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 976)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 616)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 336)
+  55834574848n => E
+  $ => A :MLOAD(SP + 416)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 336)
+  $ => A :XOR
+  A :MSTORE(SP + 336)
+  42949672960n => E
+  $ => A :MLOAD(SP + 416)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 336)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 448)
+  $ => B :ADD
+  A :MSTORE(SP + 336)
+  $ => A :MLOAD(SP + 360)
+  B => C
+  $ => B :MLOAD(SP + 512)
+  $ => A :ADD
+  A :MSTORE(SP + 328)
+  $ => B :MLOAD(SP + 408)
+  $ => A :MLOAD(SP + 368)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 328)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 408)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 328)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 320)
+  90194313216n => E
+  $ => A :MLOAD(SP + 328)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 320)
+  $ => A :XOR
+  A :MSTORE(SP + 320)
+  30064771072n => E
+  $ => A :MLOAD(SP + 328)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 320)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  9568029435643297792n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 344)
+  $ => A :ADD
+  A :MSTORE(SP + 312)
+  B :MSTORE(SP + 320)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 312)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 312)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 392)
+  A => C
+  $ => A :MLOAD(SP + 352)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 312)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 352)
+  B => D
+  $ => B :MLOAD(SP + 392)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 304)
+  107374182400n => E
+  $ => A :MLOAD(SP + 896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 896)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 896)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 936)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 576)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 376)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 296)
+  55834574848n => E
+  $ => A :MLOAD(SP + 376)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 296)
+  $ => A :XOR
+  A :MSTORE(SP + 296)
+  42949672960n => E
+  $ => A :MLOAD(SP + 376)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 296)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 408)
+  $ => B :ADD
+  A :MSTORE(SP + 296)
+  $ => A :MLOAD(SP + 320)
+  B => C
+  $ => B :MLOAD(SP + 472)
+  $ => A :ADD
+  A :MSTORE(SP + 288)
+  $ => B :MLOAD(SP + 368)
+  $ => A :MLOAD(SP + 328)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 288)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 368)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 280)
+  90194313216n => E
+  $ => A :MLOAD(SP + 288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 280)
+  $ => A :XOR
+  A :MSTORE(SP + 280)
+  30064771072n => E
+  $ => A :MLOAD(SP + 288)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 280)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  10144078919058325504n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 304)
+  $ => A :ADD
+  A :MSTORE(SP + 272)
+  B :MSTORE(SP + 280)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 272)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 272)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 352)
+  A => C
+  $ => A :MLOAD(SP + 312)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 272)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 312)
+  B => E
+  $ => B :MLOAD(SP + 352)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 264)
+  107374182400n => E
+  $ => A :MLOAD(SP + 856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 856)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 856)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 896)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 536)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 256)
+  55834574848n => E
+  $ => A :MLOAD(SP + 336)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 256)
+  $ => A :XOR
+  A :MSTORE(SP + 256)
+  42949672960n => E
+  $ => A :MLOAD(SP + 336)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 256)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 368)
+  $ => B :ADD
+  A :MSTORE(SP + 256)
+  $ => A :MLOAD(SP + 280)
+  B => E
+  $ => B :MLOAD(SP + 432)
+  $ => A :ADD
+  A :MSTORE(SP + 248)
+  $ => B :MLOAD(SP + 328)
+  $ => A :MLOAD(SP + 288)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 248)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 328)
+  $ => CTX :XOR
+  E => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 240)
+  90194313216n => E
+  $ => A :MLOAD(SP + 248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 240)
+  $ => A :XOR
+  A :MSTORE(SP + 240)
+  30064771072n => E
+  $ => A :MLOAD(SP + 248)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 240)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  10430055236243554304n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 264)
+  $ => A :ADD
+  A :MSTORE(SP + 232)
+  B :MSTORE(SP + 240)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 232)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 232)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 312)
+  A => E
+  $ => A :MLOAD(SP + 272)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 232)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 272)
+  B => C
+  $ => B :MLOAD(SP + 312)
+  $ => CTX :AND
+  C => A
+  CTX => B
+  $ => B :XOR
+  E => A
+  $ => A :ADD
+  A :MSTORE(SP + 224)
+  107374182400n => E
+  $ => A :MLOAD(SP + 816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 816)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 816)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 856)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 496)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 216)
+  55834574848n => E
+  $ => A :MLOAD(SP + 296)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 216)
+  $ => A :XOR
+  A :MSTORE(SP + 216)
+  42949672960n => E
+  $ => A :MLOAD(SP + 296)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 216)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 328)
+  $ => B :ADD
+  A :MSTORE(SP + 216)
+  $ => A :MLOAD(SP + 240)
+  B => C
+  $ => B :MLOAD(SP + 392)
+  $ => A :ADD
+  A :MSTORE(SP + 208)
+  $ => B :MLOAD(SP + 288)
+  $ => A :MLOAD(SP + 248)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 208)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 288)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 208)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 200)
+  90194313216n => E
+  $ => A :MLOAD(SP + 208)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 200)
+  $ => A :XOR
+  A :MSTORE(SP + 200)
+  30064771072n => E
+  $ => A :MLOAD(SP + 208)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 200)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  11840083176930148352n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 224)
+  $ => A :ADD
+  A :MSTORE(SP + 192)
+  B :MSTORE(SP + 200)
+  128849018880n => E
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  81604378624n => E
+  $ => A :MLOAD(SP + 192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  42949672960n => E
+  $ => A :MLOAD(SP + 192)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  $ => B :MLOAD(SP + 272)
+  A => C
+  $ => A :MLOAD(SP + 232)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 192)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 232)
+  B => D
+  $ => B :MLOAD(SP + 272)
+  $ => CTX :AND
+  D => A
+  CTX => B
+  $ => B :XOR
+  C => A
+  $ => A :ADD
+  A :MSTORE(SP + 184)
+  107374182400n => E
+  $ => A :MLOAD(SP + 776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 776)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 776)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => B :XOR
+  $ => A :MLOAD(SP + 816)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 456)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 256)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 176)
+  55834574848n => E
+  $ => A :MLOAD(SP + 256)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 176)
+  $ => A :XOR
+  A :MSTORE(SP + 176)
+  42949672960n => E
+  $ => A :MLOAD(SP + 256)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 176)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 288)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 352)
+  A => C
+  $ => A :MLOAD(SP + 200)
+  $ => A :ADD
+  A :MSTORE(SP + 176)
+  $ => B :MLOAD(SP + 248)
+  $ => A :MLOAD(SP + 208)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 176)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 248)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 168)
+  90194313216n => E
+  $ => A :MLOAD(SP + 176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 168)
+  $ => A :XOR
+  A :MSTORE(SP + 168)
+  30064771072n => E
+  $ => A :MLOAD(SP + 176)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 168)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  13761210417659510784n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 184)
+  $ => A :ADD
+  B :MSTORE(SP + 168)
+  A :MSTORE(SP + 160)
+  $ => B :MLOAD(SP + 232)
+  $ => A :MLOAD(SP + 192)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 160)
+  CTX => B
+  $ => B :AND
+  $ => A :MLOAD(SP + 192)
+  B => E
+  $ => B :MLOAD(SP + 232)
+  $ => CTX :AND
+  E => A
+  CTX => B
+  $ => A :XOR
+  $ => B :MLOAD(SP + 128)
+  $ => A :ADD
+  A => CTX
+  128849018880n => E
+  $ => A :MLOAD(SP + 160)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 152)
+  81604378624n => E
+  $ => A :MLOAD(SP + 160)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 152)
+  $ => A :XOR
+  A :MSTORE(SP + 152)
+  42949672960n => E
+  $ => A :MLOAD(SP + 160)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 152)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  A :MSTORE(SP + 152)
+  107374182400n => E
+  $ => A :MLOAD(SP + 736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => CTX
+  60129542144n => E
+  $ => A :MLOAD(SP + 736)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  CTX => A
+  $ => A :XOR
+  A => CTX
+  12884901888n => E
+  $ => A :MLOAD(SP + 736)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  CTX => A
+  $ => B :XOR
+  $ => A :MLOAD(SP + 776)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 416)
+  $ => A :ADD
+  A => CTX
+  64424509440n => E
+  $ => A :MLOAD(SP + 216)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 144)
+  55834574848n => E
+  $ => A :MLOAD(SP + 216)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 144)
+  $ => A :XOR
+  A :MSTORE(SP + 144)
+  42949672960n => E
+  $ => A :MLOAD(SP + 216)
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  A => B
+  $ => A :MLOAD(SP + 144)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  $ => B :MLOAD(SP + 248)
+  $ => A :ADD
+  $ => B :MLOAD(SP + 312)
+  A => C
+  $ => A :MLOAD(SP + 168)
+  $ => A :ADD
+  A :MSTORE(SP + 144)
+  $ => B :MLOAD(SP + 208)
+  $ => A :MLOAD(SP + 176)
+  $ => CTX :XOR
+  $ => A :MLOAD(SP + 144)
+  CTX => B
+  $ => B :AND
+  B => A
+  $ => B :MLOAD(SP + 208)
+  $ => CTX :XOR
+  C => A
+  CTX => B
+  $ => A :ADD
+  A => CTX
+  111669149696n => E
+  $ => A :MLOAD(SP + 144)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A :MSTORE(SP + 136)
+  90194313216n => E
+  $ => A :MLOAD(SP + 144)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 136)
+  $ => A :XOR
+  A :MSTORE(SP + 136)
+  30064771072n => E
+  $ => A :MLOAD(SP + 144)
+  A :MSTORE(SP)
+  E :MSTORE(SP + 1)
+  SP + 2 => SP
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  0 => D
+  0 => C
+  $${var _mulShlArith = A * B}
+  ${_mulShlArith / 18446744073709551616} => D
+  ${_mulShlArith % 18446744073709551616} => E :ARITH
+  ;; shl
+  SP - 2 => SP
+  $ => C :MLOAD(SP)
+  E :MSTORE(SP)
+  $ => E :MLOAD(SP + 1)
+  137438953472n => A
+  E => B
+  $ => E :SUB
+  C => A
+  SP + 1 => SP
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  SP - 1 => SP
+  ;; shr
+  $ => B :MLOAD(SP)
+  $ => A :OR
+  A => B
+  $ => A :MLOAD(SP + 136)
+  $ => B :XOR
+  CTX => A
+  $ => A :ADD
+  14299343272655454208n => B
+  $ => B :ADD
+  $ => A :MLOAD(SP + 152)
+  $ => A :ADD
+  A :MSTORE(SP + 128)
+  $ => A :MLOAD(SP + 160)
+  B => D
+  $ => B :MLOAD(SP + 16)
+  $ => C :ADD
+  $ => A :MLOAD(SP + 272)
+  $ => B :MLOAD(SP + 40)
+  C :MSTORE(SP + 120)
+  $ => A :ADD
+  D => B
+  $ => B :ADD
+  B :MSTORE(SP + 96)
+  $ => B :MLOAD(SP + 8)
+  $ => A :MLOAD(SP + 192)
+  $ => D :ADD
+  $ => A :MLOAD(SP + 144)
+  $ => B :MLOAD(SP + 56)
+  D :MSTORE(SP + 112)
+  $ => B :ADD
+  B :MSTORE(SP + 88)
+  $ => B :MLOAD(SP + 104)
+  $ => A :MLOAD(SP + 232)
+  $ => B :ADD
+  B :MSTORE(SP + 104)
+  $ => B :MLOAD(SP + 48)
+  $ => A :MLOAD(SP + 176)
+  $ => B :ADD
+  B :MSTORE(SP + 80)
+  $ => B :MLOAD(SP + 32)
+  $ => A :MLOAD(SP + 208)
+  $ => CTX :ADD
+  274877906944n => B
+  $ => A :MLOAD(SP + 64)
+  $ => E :ADD
+  E => A
+  $ => B :MLOAD(SP + 2800)
+  $ => A :EQ
+  1 - A => A
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_3_4)
+  :JMP(label_3_5)
+label_3_4:
+  $ => A :MLOAD(SP + 112)
+  $ => B :MLOAD(SP + 120)
+  $ => C :MLOAD(SP + 112)
+  C :MSTORE(SP + 8)
+  $ => C :MLOAD(SP + 120)
+  C :MSTORE(SP + 16)
+  CTX :MSTORE(SP + 32)
+  $ => C :MLOAD(SP + 96)
+  C :MSTORE(SP + 40)
+  $ => C :MLOAD(SP + 80)
+  C :MSTORE(SP + 48)
+  $ => C :MLOAD(SP + 88)
+  C :MSTORE(SP + 56)
+  E :MSTORE(SP + 64)
+  :JMP(label_3_3)
+label_3_5:
+  $ => A :MLOAD(SP + 24)
+  :JMP(label_3_7)
+label_3_7:
+  $ => A :MLOAD(SP + 24)
+  $ => C :MLOAD(A)
+  C => A
+  $ => B :MLOAD(SP)
+  $ => C :ADD
+  CTX :MSTORE(C + 28)
+  $ => A :MLOAD(SP + 24)
+  $ => C :MLOAD(A)
+  C => A
+  $ => C :ADD
+  $ => CTX :MLOAD(SP + 80)
+  CTX :MSTORE(C + 24)
+  $ => A :MLOAD(SP + 24)
+  $ => D :MLOAD(A)
+  D => A
+  $ => D :ADD
+  $ => C :MLOAD(SP + 88)
+  C :MSTORE(D + 20)
+  $ => A :MLOAD(SP + 24)
+  $ => E :MLOAD(A)
+  E => A
+  $ => E :ADD
+  $ => CTX :MLOAD(SP + 96)
+  CTX :MSTORE(E + 16)
+  $ => A :MLOAD(SP + 24)
+  $ => CTX :MLOAD(A)
+  CTX => A
+  $ => A :ADD
+  $ => C :MLOAD(SP + 104)
+  C :MSTORE(A + 12)
+  $ => A :MLOAD(SP + 24)
+  $ => CTX :MLOAD(A)
+  CTX => A
+  $ => CTX :ADD
+  $ => D :MLOAD(SP + 112)
+  D :MSTORE(CTX + 8)
+  $ => A :MLOAD(SP + 24)
+  $ => CTX :MLOAD(A)
+  CTX => A
+  $ => CTX :ADD
+  $ => C :MLOAD(SP + 120)
+  C :MSTORE(CTX + 4)
+  $ => A :MLOAD(SP + 24)
+  $ => A :MLOAD(A)
+  $ => C :ADD
+  $ => B :MLOAD(SP + 128)
+  B :MSTORE(C)
+  $ => C :MLOAD(SP - 1)
+  $ => D :MLOAD(SP - 2)
+  $ => E :MLOAD(SP - 3)
+  $ => B :MLOAD(SP - 4)
+  $ => CTX :MLOAD(SP - 5)
+  SP - 357 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+function_4:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 2 => SP
+  C :MSTORE(SP - 1)
+  $ => C :MLOAD(fp + 16)
+  SP + 1 => SP
+  C :MSTORE(SP)
+  zkPC + 2 => RR
+  :JMP(function_5)
+  SP - 1 => SP
+  $ => C :MLOAD(SP - 1)
+  SP - 2 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+function_5:
+  SP + 1 => SP
+  RR :MSTORE(SP - 1)
+  SP + 11 => SP
+  C :MSTORE(SP - 1)
+  D :MSTORE(SP - 2)
+  E :MSTORE(SP - 3)
+  B :MSTORE(SP - 4)
+  CTX :MSTORE(SP - 5)
+  A :MSTORE(SP)
+  B :MSTORE(SP + 8)
+  CTX :MSTORE(SP + 24)
+  $ => A :MLOAD(fp + 16)
+  A :MSTORE(SP + 16)
+  64424509440n => B
+  A => C
+  B => A
+  C => B
+  $ => A :LT
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_2)
+  $ => E :MLOAD(SP + 16)
+  $ => C :MLOAD(SP)
+  C :MSTORE(SP + 16)
+  :JMP(label_5_17)
+label_5_2:
+  0n => A
+  $ => B :MLOAD(SP)
+  $ => A :SUB
+  12884901888n => B
+  $ => B :AND
+  $ => A :MLOAD(SP)
+  $ => C :ADD
+  C => CTX
+  B :MSTORE(SP + 32)
+  0n => B
+  $ => A :MLOAD(SP + 32)
+  $ => A :EQ
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_3)
+  :JMP(label_5_4)
+label_5_3:
+  $ => A :MLOAD(SP + 16)
+  $ => B :MLOAD(SP + 32)
+  :JMP(label_5_9)
+label_5_4:
+  $ => E :MLOAD(SP + 24)
+  $ => B :MLOAD(SP)
+  :JMP(label_5_5)
+label_5_5:
+  $ => A :MLOAD(E)
+  E :MSTORE(SP + 24)
+  $ => A :ADD
+  B => C
+  $ => B :MLOAD(SP + 8)
+  B :MSTORE(A)
+  4294967296n => B
+  C => A
+  $ => E :ADD
+  E => A
+  CTX => B
+  $ => A :LT
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_6)
+  :JMP(label_5_7)
+label_5_6:
+  E => B
+  $ => E :MLOAD(SP + 24)
+  :JMP(label_5_5)
+label_5_7:
+  $ => A :MLOAD(SP + 16)
+  $ => B :MLOAD(SP + 32)
+  :JMP(label_5_9)
+label_5_9:
+  $ => A :SUB
+  18446744056529682432n => B
+  $ => B :AND
+  A :MSTORE(SP + 32)
+  CTX => A
+  $ => C :ADD
+  B => A
+  C :MSTORE(SP + 16)
+  4294967296n => B
+  $ => A :SLT
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_10)
+  :JMP(label_5_11)
+label_5_10:
+  :JMP(label_5_16)
+label_5_11:
+  1095216660480n => B
+  $ => A :MLOAD(SP + 8)
+  $ => B :AND
+  72340172821233664n => E
+  B :MSTORE(SP)
+  0 => D
+  0 => C
+  4294967296n => B
+  ${E / B} => A
+  E:ARITH
+  $ => B :MLOAD(SP)
+  ${A * B} => E :ARITH
+  $ => A :MLOAD(SP + 24)
+  CTX => B
+  :JMP(label_5_12)
+label_5_12:
+  $ => CTX :MLOAD(A)
+  CTX => A
+  $ => CTX :ADD
+  B => A
+  E :MSTORE(CTX)
+  17179869184n => B
+  $ => CTX :ADD
+  CTX => A
+  $ => B :MLOAD(SP + 16)
+  $ => A :LT
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_13)
+  :JMP(label_5_14)
+label_5_13:
+  $ => A :MLOAD(SP + 24)
+  CTX => B
+  :JMP(label_5_12)
+label_5_14:
+  :JMP(label_5_16)
+label_5_16:
+  12884901888n => B
+  $ => A :MLOAD(SP + 32)
+  $ => E :AND
+  :JMP(label_5_17)
+label_5_17:
+  0n => B
+  E => A
+  $ => A :EQ
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  E => CTX
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_18)
+  :JMP(label_5_19)
+label_5_18:
+  :JMP(label_5_24)
+label_5_19:
+  $ => A :MLOAD(SP + 16)
+  CTX => B
+  $ => E :ADD
+  A => B
+  $ => A :MLOAD(SP + 24)
+  :JMP(label_5_20)
+label_5_20:
+  $ => A :MLOAD(SP + 24)
+  $ => C :MLOAD(A)
+  C => A
+  $ => C :ADD
+  B => A
+  $ => B :MLOAD(SP + 8)
+  B :MSTORE(C)
+  4294967296n => B
+  $ => CTX :ADD
+  CTX => A
+  E => B
+  $ => A :LT
+  4294967296n => B
+  0 => D
+  0 => C
+  ${A * B} => A :ARITH
+  A => B
+  0 => A
+  $ => A :EQ
+  A :JMPZ(label_5_21)
+  :JMP(label_5_22)
+label_5_21:
+  $ => A :MLOAD(SP + 24)
+  CTX => B
+  :JMP(label_5_20)
+label_5_22:
+  :JMP(label_5_24)
+label_5_24:
+  $ => A :MLOAD(SP)
+  $ => C :MLOAD(SP - 1)
+  $ => D :MLOAD(SP - 2)
+  $ => E :MLOAD(SP - 3)
+  $ => B :MLOAD(SP - 4)
+  $ => CTX :MLOAD(SP - 5)
+  SP - 11 => SP
+  $ => RR :MLOAD(SP - 1)
+  SP - 1 => SP
+  :JMP(RR)
+finalizeExecution:
+  ${beforeLast()}  :JMPN(finalizeExecution)
+                   :JMP(start)
+INCLUDE "helpers/2-exp.zkasm"

--- a/cranelift/zkasm_data/benchmarks/sha256/state.csv
+++ b/cranelift/zkasm_data/benchmarks/sha256/state.csv
@@ -1,2 +1,2 @@
 Test,Status,Cycles
-from_rust,compilation failed,
+from_rust,runtime error,


### PR DESCRIPTION
This is the last tweak to get SHA256 benchmark to compile.
It still crashes due to memory ops syntax error, but we'll fix that next.