### PR TITLE
Implement address cast with shifts

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -917,9 +917,18 @@ impl MachInstEmit for Inst {
                         if r == context_reg() {
                             put_string(&format!("0 => {}\n", reg_name(rd.to_reg())), sink);
                         } else {
-                            // TODO(akashin): Get rid of this unsound logic when 32-bit registers
-                            // are stored without shifts.
-                            put_string(&format!("${{ {} >> 32 }} => E\n", reg_name(r)), sink);
+                            debug_assert_eq!(r, a0());
+                            Inst::LoadConst64 {
+                                rd: writable_e0(),
+                                imm: 32,
+                            }
+                            .emit(&[], sink, emit_info, state);
+                            Inst::Shru32 {
+                                rd: writable_e0(),
+                                rs1: r,
+                                rs2: e0(),
+                            }
+                            .emit(&[], sink, emit_info, state);
                             put_string(
                                 &format!(
                                     "$ => {} :MLOAD(MEM:{})\n",
@@ -960,10 +969,18 @@ impl MachInstEmit for Inst {
 
                 match to {
                     AMode::RegOffset(r, off, _) => {
-                        debug_assert_eq!(r, e0());
-                        // TODO(akashin): Get rid of this unsound logic when 32-bit registers
-                        // are stored without shifts.
-                        put_string(&format!("${{ E >> 32 }} => E\n"), sink);
+                        debug_assert_eq!(r, a0());
+                        Inst::LoadConst64 {
+                            rd: writable_e0(),
+                            imm: 32,
+                        }
+                        .emit(&[], sink, emit_info, state);
+                        Inst::Shru32 {
+                            rd: writable_e0(),
+                            rs1: r,
+                            rs2: e0(),
+                        }
+                        .emit(&[], sink, emit_info, state);
                         put_string(
                             &format!(
                                 "{} :MSTORE(MEM:{})\n",

--- a/cranelift/codegen/src/isa/zkasm/inst/mod.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/mod.rs
@@ -429,17 +429,22 @@ fn zkasm_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
         }
         &Inst::Load { rd, from, .. } => {
             if let Some(r) = from.get_allocatable_register() {
-                collector.reg_use(r);
+                collector.reg_fixed_use(r, a0());
             }
             let mut clobbered = PRegSet::empty();
+            clobbered.add(a0().to_real_reg().unwrap().into());
             clobbered.add(e0().to_real_reg().unwrap().into());
             collector.reg_clobbers(clobbered);
             collector.reg_def(rd);
         }
         &Inst::Store { to, src, .. } => {
             if let Some(r) = to.get_allocatable_register() {
-                collector.reg_fixed_use(r, e0());
+                collector.reg_fixed_use(r, a0());
             }
+            let mut clobbered = PRegSet::empty();
+            clobbered.add(a0().to_real_reg().unwrap().into());
+            clobbered.add(e0().to_real_reg().unwrap().into());
+            collector.reg_clobbers(clobbered);
             collector.reg_use(src);
         }
         &Inst::Args { ref args } => {

--- a/cranelift/codegen/src/isa/zkasm/inst/regs.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/regs.rs
@@ -47,6 +47,10 @@ pub fn writable_c0() -> Writable<Reg> {
 pub fn writable_d0() -> Writable<Reg> {
     Writable::from_reg(d0())
 }
+#[inline]
+pub fn writable_e0() -> Writable<Reg> {
+    Writable::from_reg(e0())
+}
 
 /// Get a reference to the zero-register.
 #[inline]

--- a/cranelift/zkasm_data/generated/memory.zkasm
+++ b/cranelift/zkasm_data/generated/memory.zkasm
@@ -12,28 +12,328 @@ function_1:
   B :MSTORE(SP - 4)
   0n => B
   8589934592n => D
-  0 => A
-  $ => E :ADD
-  ${ E >> 32 } => E
+  CTX => A
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  $ => C :MLOAD(MEM:E)
+  C => A
+  $ => A :ADD
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
   D :MSTORE(MEM:E)
   34359738368n => B
   12884901888n => C
-  0 => A
-  $ => E :ADD
-  ${ E >> 32 } => E
+  CTX => A
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  $ => D :MLOAD(MEM:E)
+  D => A
+  $ => A :ADD
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
   C :MSTORE(MEM:E)
   0n => B
-  0 => A
-  $ => A :ADD
-  ${ A >> 32 } => E
-  $ => A :MLOAD(MEM:E)
-  A => C
-  34359738368n => B
-  0 => A
-  $ => A :ADD
-  ${ A >> 32 } => E
-  $ => B :MLOAD(MEM:E)
+  CTX => A
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  $ => C :MLOAD(MEM:E)
   C => A
+  $ => A :ADD
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  $ => B :MLOAD(MEM:E)
+  B => D
+  34359738368n => B
+  CTX => A
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  $ => C :MLOAD(MEM:E)
+  C => A
+  $ => A :ADD
+  32n => E
+  E :MSTORE(SP)
+  0 => D
+  A => E
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => E :MLOAD(SP)
+  A :MSTORE(SP)
+  0 => D
+  4294967296n => B
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  A => E
+  32 => B
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E:ARITH
+  $ => A :MLOAD(SP)
+  C => E
+;;NEED_INCLUDE: 2-exp
+  zkPC + 2 => RR
+    :JMP(@two_power + E)
+  A => E
+  0 => D
+  ${E / B} => A
+  ${E % B} => C
+  E :ARITH
+  0 => C
+  4294967296n => B
+  ${A * B} => E
+  0 => D
+  E :ARITH
+  E => A
+  $ => B :MLOAD(MEM:E)
+  D => A
   $ => A :ADD
   21474836480n => B
   B :ASSERT

--- a/cranelift/zkasm_data/state.csv
+++ b/cranelift/zkasm_data/state.csv
@@ -19,7 +19,7 @@ locals,pass,17
 locals_simple,pass,15
 lt_s,pass,34
 lt_u,pass,34
-memory,pass,45
+memory,runtime error,
 mul,pass,31
 ne,pass,36
 nop,pass,15

--- a/docs/zkasm/test_summary.csv
+++ b/docs/zkasm/test_summary.csv
@@ -1,5 +1,5 @@
 Suite path,Passing count,Total count,Total cycles
-cranelift/zkasm_data,26,27,1066
+cranelift/zkasm_data,25,27,1021
 cranelift/zkasm_data/benchmarks/fibonacci,3,3,282056
 cranelift/zkasm_data/benchmarks/sha256,0,1,0
 cranelift/zkasm_data/spectest/conversions,3,24,45


### PR DESCRIPTION
This is an attempt to rewrite unsound logic for 32-bin addresses to a proper implementation.

Currently, it does pass the test due to the assert failing.