### PR TITLE
perf: optimize `benchmarks/fibonacci/handwritten_wat.wat`

### DIFF
--- a/cranelift/zkasm_data/benchmarks/fibonacci/generated/handwritten_wat.zkasm
+++ b/cranelift/zkasm_data/benchmarks/fibonacci/generated/handwritten_wat.zkasm
@@ -5,33 +5,35 @@ start:
 function_1:
   SP + 1 => SP
   RR :MSTORE(SP - 1)
-  SP + 6 => SP
+  SP + 5 => SP
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
   B :MSTORE(SP - 4)
-  0n => A  ;; LoadConst32
-  A :MSTORE(SP + 8)
+  10000n => A  ;; LoadConst32
+  A => E
   0n => A  ;; LoadConst64
   1n => B  ;; LoadConst64
   :JMP(label_1_1)
 label_1_1:
-  $ => E :ADD
+  $ => C :ADD
   B :MSTORE(SP)
   1n => B  ;; LoadConst32
-  $ => A :MLOAD(SP + 8)
-  $ => A :ADD
+  E => A
+  $ => A :SUB
   4294967295n => B  ;; LoadConst64
   $ => A :AND
-  A :MSTORE(SP + 8)
-  10000n => B  ;; LoadConst32
-  $ => A :EQ
-  A => B
+  A => D
+  A => E
+  D => B
   0 => A
   $ => A :EQ
-  A :JMPZ(label_1_3)
+  A :JMPZ(label_1_2)
+  :JMP(label_1_3)
+label_1_2:
+  D => E
   $ => A :MLOAD(SP)
-  E => B
+  C => B
   :JMP(label_1_1)
 label_1_3:
   15574651946073070043n => B  ;; LoadConst64
@@ -41,7 +43,7 @@ label_1_3:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP - 6 => SP
+  SP - 5 => SP
   $ => RR :MLOAD(SP - 1)
   SP - 1 => SP
   :JMP(RR)

--- a/cranelift/zkasm_data/benchmarks/fibonacci/handwritten_wat.wat
+++ b/cranelift/zkasm_data/benchmarks/fibonacci/handwritten_wat.wat
@@ -4,27 +4,24 @@
 	(local $counter i32)
 	(local $fp i64)
 	(local $f i64)
-	(local.set $counter (i32.const 0))
+	;; Decrease counter, so the branch to $loop happens as long as $counter > 0.
+	;; This allows to safe a comparison (e.g. $counter > 0) and instead just do
+	;; (br_if $loop (local.get $counter)).
+	(local.set $counter (i32.const 10000))
 	(local.set $fp (i64.const 0))
 	(local.set $f (i64.const 1))
-	(block
-	 (loop
-		(local.get $fp)
-		(local.get $f)
+	(loop $loop
+	    (local.get $fp)
+	    (local.get $f)
 		(local.set $fp (local.get $f))
 		(local.set $f (i64.add))
 		(local.set $counter
-		 (i32.add
+			(i32.sub
+				(local.get $counter)
+				(i32.const 1)))
+		(br_if $loop
 			(local.get $counter)
-			(i32.const 1)))
-		(br_if 1
-		 (i32.eq
-			(local.get $counter)
-			(i32.const 10000)
-		 )
 		)
-		(br 0)
-	 )
 	)
 	(local.get $fp)
 	(i64.const -2872092127636481573)


### PR DESCRIPTION
Taking inspiration from WASM generated by the Rust compiler (e.g. [here](https://github.com/near/wasmtime/issues/162#issue-2043620954)), this removes a `block` and decreases `$counter` to avoid doing a comparison like `$counter == 10000`. More details in the comment added to `handwritten_wat.wat`.

Even though the WAT is simpler, the number of cycles required to executed the generated zkASM does not change. Understanding why there is no reduction of cycles potentially could hint at some optimizations for the generated zkASM.

CC @akashin as this is part of the investigations carried out for #151.