### PR TITLE
Support loads and stores at FPOffset

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/abi.rs
+++ b/cranelift/codegen/src/isa/zkasm/abi.rs
@@ -169,8 +169,7 @@ impl ABIMachineSpec for ZkAsmMachineDeps {
     }
 
     fn fp_to_arg_offset(_call_conv: isa::CallConv, _flags: &settings::Flags) -> i64 {
-        // lr fp.
-        16
+        8
     }
 
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Inst {

--- a/cranelift/codegen/src/isa/zkasm/inst/args.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/args.rs
@@ -143,7 +143,7 @@ impl AMode {
         match self {
             &AMode::RegOffset(reg, ..) => Some(reg),
             &AMode::SPOffset(..) => Some(stack_reg()),
-            &AMode::FPOffset(..) => Some(fp_reg()),
+            &AMode::FPOffset(..) => Some(stack_reg()),
             &AMode::NominalSPOffset(..) => Some(stack_reg()),
             &AMode::Const(..) | AMode::Label(..) | AMode::Global(..) => None,
         }
@@ -151,6 +151,9 @@ impl AMode {
 
     pub(crate) fn get_offset_with_state(&self, state: &EmitState) -> i64 {
         match self {
+            // We don't have a frame pointer on ZKASM, but it can be easily computed
+            // based on the nominal sp.
+            &AMode::FPOffset(offset, _) => offset + state.nominal_sp_to_fp,
             &AMode::NominalSPOffset(offset, _) => offset + state.virtual_sp_offset,
             _ => self.get_offset(),
         }

--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -600,23 +600,13 @@ impl MachInstEmit for Inst {
                             sink,
                         );
                     }
-                    AMode::SPOffset(..) | AMode::NominalSPOffset(..) => {
+                    AMode::SPOffset(..) | AMode::NominalSPOffset(..) | AMode::FPOffset(..) => {
                         assert_eq!(offset % 8, 0);
                         put_string(
                             &format!(
                                 "$ => {} :MLOAD({})\n",
                                 reg_name(rd.to_reg()),
                                 access_reg_with_offset(stack_reg(), offset / 8),
-                            ),
-                            sink,
-                        );
-                    }
-                    AMode::FPOffset(..) => {
-                        put_string(
-                            &format!(
-                                "$ => {} :MLOAD({})\n",
-                                reg_name(rd.to_reg()),
-                                access_reg_with_offset(fp_reg(), offset),
                             ),
                             sink,
                         );
@@ -648,23 +638,13 @@ impl MachInstEmit for Inst {
                             sink,
                         );
                     }
-                    AMode::SPOffset(..) | AMode::NominalSPOffset(..) => {
+                    AMode::SPOffset(..) | AMode::NominalSPOffset(..) | AMode::FPOffset(..) => {
                         assert_eq!(offset % 8, 0);
                         put_string(
                             &format!(
                                 "{} :MSTORE({})\n",
                                 reg_name(src),
                                 access_reg_with_offset(stack_reg(), offset / 8),
-                            ),
-                            sink,
-                        );
-                    }
-                    AMode::FPOffset(..) => {
-                        put_string(
-                            &format!(
-                                "{} :MSTORE({})\n",
-                                reg_name(src),
-                                access_reg_with_offset(fp_reg(), offset),
                             ),
                             sink,
                         );

--- a/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
+++ b/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
@@ -1664,7 +1664,7 @@ function_2:
   SP - 1 => SP
   C :MSTORE(SP - 1)
   SP - 2 => SP
-  $ => C :MLOAD(fp + 16)
+  $ => C :MLOAD(SP + 3)
   SP - 1 => SP
   C :MSTORE(SP)
   zkPC + 2 => RR
@@ -1685,7 +1685,7 @@ function_3:
   SP - 1182 => SP
   A :MSTORE(SP)
   B :MSTORE(SP + 1)
-  $ => A :MLOAD(fp + 16)
+  $ => A :MLOAD(SP + 1183)
   A :MSTORE(SP + 2)
   0 => A  ;; LoadExtName(User(userextname0))
   $ => B :MLOAD(SP)
@@ -28172,7 +28172,7 @@ function_4:
   SP - 1 => SP
   C :MSTORE(SP - 1)
   SP - 2 => SP
-  $ => C :MLOAD(fp + 16)
+  $ => C :MLOAD(SP + 3)
   SP - 1 => SP
   C :MSTORE(SP)
   zkPC + 2 => RR
@@ -28193,7 +28193,7 @@ function_5:
   SP - 10 => SP
   A :MSTORE(SP)
   B :MSTORE(SP + 1)
-  $ => A :MLOAD(fp + 16)
+  $ => A :MLOAD(SP + 11)
   A :MSTORE(SP + 2)
   15n => B  ;; LoadConst32
   A => C


### PR DESCRIPTION
This is another change necessary to support SHA256 benchmark (https://github.com/near/wasmtime/pull/185).
Concretely, frame pointer access is used to read arguments to the function passed using stack when there are not enough registers.