### PR TITLE
Fix prologue frame setup/restore

### DIFF
--- a/cranelift/zkasm_data/benchmarks/fibonacci/generated/from_rust.zkasm
+++ b/cranelift/zkasm_data/benchmarks/fibonacci/generated/from_rust.zkasm
@@ -10,8 +10,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -81,8 +81,8 @@ label_1_3:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/benchmarks/fibonacci/generated/handwritten_wat.zkasm
+++ b/cranelift/zkasm_data/benchmarks/fibonacci/generated/handwritten_wat.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -40,8 +40,8 @@ label_1_3:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
+++ b/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
@@ -17,8 +17,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -1656,12 +1656,12 @@ label_1_6:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 function_2:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   SP - 2 => SP
   $ => C :MLOAD(SP + 3)
@@ -1672,12 +1672,12 @@ function_2:
   SP + 1 => SP
   SP + 2 => SP
   $ => C :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 function_3:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -28164,12 +28164,12 @@ label_3_7:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 function_4:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   SP - 2 => SP
   $ => C :MLOAD(SP + 3)
@@ -28180,12 +28180,12 @@ function_4:
   SP + 1 => SP
   SP + 2 => SP
   $ => C :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 function_5:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -28375,8 +28375,8 @@ label_5_24:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/_should_fail_unreachable.zkasm
+++ b/cranelift/zkasm_data/generated/_should_fail_unreachable.zkasm
@@ -4,6 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
+  SP - 1 => SP
+  RR :MSTORE(SP)
   UNREACHABLE: unreachable
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/add.zkasm
+++ b/cranelift/zkasm_data/generated/add.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   999999999n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/add_func.zkasm
+++ b/cranelift/zkasm_data/generated/add_func.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2n => A  ;; LoadConst32
@@ -16,12 +16,12 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 function_2:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   $ => A :ADD
@@ -29,8 +29,8 @@ function_2:
   $ => A :AND
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/and.zkasm
+++ b/cranelift/zkasm_data/generated/and.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/counter.zkasm
+++ b/cranelift/zkasm_data/generated/counter.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ label_1_3:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/div.zkasm
+++ b/cranelift/zkasm_data/generated/div.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/eqz.zkasm
+++ b/cranelift/zkasm_data/generated/eqz.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/global.zkasm
+++ b/cranelift/zkasm_data/generated/global.zkasm
@@ -8,8 +8,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   D :MSTORE(SP - 1)
   B :MSTORE(SP - 2)
   SP - 2 => SP
@@ -25,8 +25,8 @@ function_1:
   SP + 2 => SP
   $ => D :MLOAD(SP - 1)
   $ => B :MLOAD(SP - 2)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i32_add_overflows.zkasm
+++ b/cranelift/zkasm_data/generated/i32_add_overflows.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i32_const.zkasm
+++ b/cranelift/zkasm_data/generated/i32_const.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i32_mul_overflows.zkasm
+++ b/cranelift/zkasm_data/generated/i32_mul_overflows.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i64_const.zkasm
+++ b/cranelift/zkasm_data/generated/i64_const.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i64_div.zkasm
+++ b/cranelift/zkasm_data/generated/i64_div.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i64_mul.zkasm
+++ b/cranelift/zkasm_data/generated/i64_mul.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -45,8 +45,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i64_mul_overflows.zkasm
+++ b/cranelift/zkasm_data/generated/i64_mul_overflows.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/i64_rem.zkasm
+++ b/cranelift/zkasm_data/generated/i64_rem.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/locals.zkasm
+++ b/cranelift/zkasm_data/generated/locals.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/locals_simple.zkasm
+++ b/cranelift/zkasm_data/generated/locals_simple.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/lt_s.zkasm
+++ b/cranelift/zkasm_data/generated/lt_s.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/lt_u.zkasm
+++ b/cranelift/zkasm_data/generated/lt_u.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/memory.zkasm
+++ b/cranelift/zkasm_data/generated/memory.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -41,8 +41,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/memory_i32.zkasm
+++ b/cranelift/zkasm_data/generated/memory_i32.zkasm
@@ -9,8 +9,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   E :MSTORE(SP - 1)
   B :MSTORE(SP - 2)
   SP - 2 => SP
@@ -167,8 +167,8 @@ function_1:
   SP + 2 => SP
   $ => E :MLOAD(SP - 1)
   $ => B :MLOAD(SP - 2)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/mul.zkasm
+++ b/cranelift/zkasm_data/generated/mul.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/ne.zkasm
+++ b/cranelift/zkasm_data/generated/ne.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -26,8 +26,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/nop.zkasm
+++ b/cranelift/zkasm_data/generated/nop.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/or.zkasm
+++ b/cranelift/zkasm_data/generated/or.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/rem.zkasm
+++ b/cranelift/zkasm_data/generated/rem.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/generated/xor.zkasm
+++ b/cranelift/zkasm_data/generated/xor.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_1.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_10.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_11.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967296n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_12.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967297n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_2.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709451616n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_3.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_4.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744071562067967n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_5.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744069414584320n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_6.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744069414584319n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_7.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744069414584321n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_8.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_9.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i32.wrap_i64_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1311768467463790320n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   10000n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294957296n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   10000n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294957296n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/conversions/generated/i64.extend_i32_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/add_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/add_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1073741823n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4042326015n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/and_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/and_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/div_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/div_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eq_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eq_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eqz_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eqz_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eqz_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eqz_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eqz_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eqz_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eqz_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eqz_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/eqz_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/eqz_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   32767n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   32768n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   65535n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   19070976n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4275863552n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend16_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend16_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   127n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   128n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   255n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   19088640n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4275878528n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/extend8_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/extend8_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ge_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ge_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -36,8 +36,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/gt_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/gt_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -37,8 +37,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/le_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/le_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -33,8 +33,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/lt_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/lt_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/mul_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/mul_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/ne_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/ne_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4042326015n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/or_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/or_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_17.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_17.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_18.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_18.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rem_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rem_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/rotl_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/rotl_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -52,8 +52,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shl_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shl_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_17.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_17.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1073741824n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_17.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_17.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/shr_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/shr_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -34,8 +34,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/sub_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/sub_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1073741823n => A  ;; LoadConst32
@@ -17,8 +17,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i32/generated/xor_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i32/generated/xor_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4042326015n => A  ;; LoadConst32
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/add_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/add_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1073741823n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4042326015n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/and_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/and_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/div_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/div_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -24,8 +24,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eq_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eq_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eqz_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eqz_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eqz_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eqz_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eqz_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eqz_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eqz_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eqz_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/eqz_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/eqz_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   32767n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   32768n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   65535n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1311768467463733248n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18364758544493084672n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend16_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend16_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   32767n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   32768n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   65535n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483647n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   2147483648n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4294967295n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   81985526906748928n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend32_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend32_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18364758544655319040n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   127n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   128n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   255n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   81985529216486656n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18364758544493064832n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/extend8_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/extend8_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -13,8 +13,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ge_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ge_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/gt_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/gt_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/le_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/le_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -23,8 +23,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/lt_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/lt_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -19,8 +19,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/mul_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/mul_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -22,8 +22,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/ne_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/ne_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   B :MSTORE(SP - 3)
@@ -20,8 +20,8 @@ function_1:
   $ => C :MLOAD(SP - 1)
   $ => D :MLOAD(SP - 2)
   $ => B :MLOAD(SP - 3)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4042326015n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/or_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/or_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_17.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_17.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_18.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_18.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rem_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rem_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -25,8 +25,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/rotl_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/rotl_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -50,8 +50,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shl_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shl_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_17.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_17.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4611686018427387904n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_s_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_s_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_11.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_11.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_12.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_12.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_13.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_13.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_14.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_14.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_15.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_15.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_16.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_16.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_17.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_17.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/shr_u_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/shr_u_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   C :MSTORE(SP - 1)
   D :MSTORE(SP - 2)
   E :MSTORE(SP - 3)
@@ -32,8 +32,8 @@ function_1:
   $ => D :MLOAD(SP - 2)
   $ => E :MLOAD(SP - 3)
   $ => B :MLOAD(SP - 4)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/sub_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/sub_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1073741823n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_1.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_1.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_10.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_10.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_2.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_2.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_3.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_3.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   1n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_4.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_4.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   0n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_5.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_5.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775807n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_6.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_6.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   9223372036854775808n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_7.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_7.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_8.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_8.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   18446744073709551615n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)

--- a/cranelift/zkasm_data/spectest/i64/generated/xor_9.zkasm
+++ b/cranelift/zkasm_data/spectest/i64/generated/xor_9.zkasm
@@ -4,8 +4,8 @@ start:
   :JMP(function_1)
   :JMP(finalizeExecution)
 function_1:
-  RR :MSTORE(SP)
   SP - 1 => SP
+  RR :MSTORE(SP)
   B :MSTORE(SP - 1)
   SP - 2 => SP
   4042326015n => A  ;; LoadConst64
@@ -15,8 +15,8 @@ function_1:
   B :ASSERT
   SP + 2 => SP
   $ => B :MLOAD(SP - 1)
-  SP + 1 => SP
   $ => RR :MLOAD(SP)
+  SP + 1 => SP
   :JMP(RR)
 finalizeExecution:
   ${beforeLast()}  :JMPN(finalizeExecution)


### PR DESCRIPTION
The previous version resulted in the same stack slot being used both by the caller and the callee. The correct setup is to have the return pointer on the top of the stack for the callee. This also aligns with riscv64 implementation.

This was necessary to fix SHA256 implementation (https://github.com/near/wasmtime/pull/185).