### PR TITLE
Add ISLE rule for heap offset symbol

### DIFF
--- a/cranelift/codegen/src/isa/zkasm/inst/emit.rs
+++ b/cranelift/codegen/src/isa/zkasm/inst/emit.rs
@@ -1475,16 +1475,7 @@ impl MachInstEmit for Inst {
                 ref name,
                 offset,
             } => {
-                // TODO(akashin): Replace this with a more general logic when we have more than
-                // one external constant.
-                let rd = allocs.next_writable(rd);
-                put_string(
-                    &format!(
-                        "{offset} => {}  ;; LoadExtName({name:?})\n",
-                        reg_name(rd.to_reg())
-                    ),
-                    sink,
-                );
+                unimplemented!("LoadExtName: {name:?}");
             }
             &Inst::TrapIfC {
                 rs1,

--- a/cranelift/codegen/src/isa/zkasm/lower.isle
+++ b/cranelift/codegen/src/isa/zkasm/lower.isle
@@ -354,8 +354,8 @@
 
 ;;;;;  Rules for `symbol_value`;;;;;;;;;
 (rule
-   (lower (symbol_value (symbol_value_data name _ offset)))
-   (load_ext_name name offset))
+   (lower (symbol_value (zkasm_base ZkasmBase.Heap)))
+   (imm $I32 0))
 
 ;;;;;  Rules for `bitcast`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/zkasm/lower.isle
+++ b/cranelift/codegen/src/isa/zkasm/lower.isle
@@ -353,6 +353,7 @@
   (load_ext_name name 0))
 
 ;;;;;  Rules for `symbol_value`;;;;;;;;;
+;; Heap starts at offset 0 in zkAsm machine memory.
 (rule
    (lower (symbol_value (zkasm_base ZkasmBase.Heap)))
    (imm $I32 0))

--- a/cranelift/codegen/src/isa/zkasm/lower/isle.rs
+++ b/cranelift/codegen/src/isa/zkasm/lower/isle.rs
@@ -375,6 +375,10 @@ impl generated_code::Context for ZkAsmIsleContext<'_, '_, MInst, ZkAsmBackend> {
             match name {
                 ExternalName::User(user_name_ref) => {
                     // All ZKASM "memory"-like accesses use this name, but different offsets.
+                    // This is our convention as is not related to the actual offsets in zkAsm
+                    // machine memory that will be used by each base.
+                    // These offsets need to be aligned with the offsets used in
+                    // `cranelift_wasm::environ::zkasm::ZkasmFuncEnvironment`.
                     if user_name_ref.index() != 0 {
                         return None;
                     }

--- a/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
+++ b/cranelift/zkasm_data/benchmarks/sha256/generated/from_rust.zkasm
@@ -41,7 +41,7 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   B :MSTORE(SP + 1)
   C :MSTORE(MEM:E)
@@ -56,7 +56,7 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   B :MSTORE(SP)
   C :MSTORE(MEM:E)
@@ -71,7 +71,7 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   B :MSTORE(SP + 10)
   C :MSTORE(MEM:E)
@@ -83,7 +83,7 @@ function_1:
   $ => B :AND
   B :MSTORE(SP + 9)
   0n => D  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   D :MSTORE(MEM:E)
   8n => B  ;; LoadConst32
@@ -98,7 +98,7 @@ function_1:
   $ => B :AND
   B :MSTORE(SP + 8)
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   53n => B  ;; LoadConst32
@@ -109,11 +109,11 @@ function_1:
   $ => B :AND
   B :MSTORE(SP + 7)
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   C :MSTORE(MEM:E + 8)
@@ -129,10 +129,10 @@ function_1:
   $ => B :AND
   B => D
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 1048600)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -148,10 +148,10 @@ function_1:
   $ => B :AND
   B => C
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(MEM:E + 1048592)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   C => B
   $ => E :ADD
   D :MSTORE(MEM:E)
@@ -167,10 +167,10 @@ function_1:
   $ => B :AND
   B => D
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 1048584)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -182,30 +182,30 @@ function_1:
   $ => B :AND
   B => D
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 1048615)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 1048576)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   C :MSTORE(MEM:E + 64)
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E + 96)
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(MEM:E + 1048608)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   D :MSTORE(MEM:E + 104)
@@ -216,11 +216,11 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B :MSTORE(SP + 6)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 8)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 6)
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -231,11 +231,11 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B => D
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 1)
   $ => E :ADD
   $ => C :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -246,11 +246,11 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B => D
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP)
   $ => E :ADD
   $ => C :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -261,11 +261,11 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B => D
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 10)
   $ => E :ADD
   $ => C :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -276,11 +276,11 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B => C
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 9)
   $ => E :ADD
   $ => D :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   C => B
   $ => E :ADD
   D :MSTORE(MEM:E)
@@ -291,11 +291,11 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B => D
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => C :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
@@ -306,16 +306,16 @@ function_1:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   B => D
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 7)
   $ => E :ADD
   $ => C :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
   11n => C  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   C :MSTORE(MEM:E + 168)
@@ -332,27 +332,27 @@ function_1:
   B => A
   4294967295n => B  ;; LoadConst64
   $ => B :AND
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   D => B
   $ => E :ADD
   C :MSTORE(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   $ => D :MLOAD(MEM:E + 1)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   D :MSTORE(MEM:E + 169)
   128n => C  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 6)
   $ => E :ADD
   C :MSTORE(MEM:E)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 96)
@@ -544,7 +544,7 @@ label_1_3:
   C => A
   4294967295n => B  ;; LoadConst64
   $ => B :AND
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(SP + 10)
   D :MSTORE(MEM:E)
@@ -583,7 +583,7 @@ label_1_5:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => D  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   D :MSTORE(MEM:E)
   216n => B  ;; LoadConst32
@@ -593,7 +593,7 @@ label_1_5:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   208n => B  ;; LoadConst32
@@ -603,7 +603,7 @@ label_1_5:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   200n => B  ;; LoadConst32
@@ -613,7 +613,7 @@ label_1_5:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   192n => B  ;; LoadConst32
@@ -623,7 +623,7 @@ label_1_5:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   184n => B  ;; LoadConst32
@@ -633,15 +633,15 @@ label_1_5:
   4294967295n => B  ;; LoadConst64
   $ => B :AND
   0n => D  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   D :MSTORE(MEM:E)
   0n => C  ;; LoadConst64
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   C :MSTORE(MEM:E + 176)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(SP + 10)
   D :MSTORE(MEM:E + 232)
@@ -667,32 +667,32 @@ label_1_5:
   SP + 1 => SP
   :JMP(label_1_6)
 label_1_6:
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 92)
   A :MSTORE(SP + 10)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 88)
   A :MSTORE(SP + 9)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 84)
   A :MSTORE(SP + 8)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 80)
   A :MSTORE(SP + 7)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 76)
   A :MSTORE(SP + 6)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 72)
   A :MSTORE(SP + 5)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 64)
   A :MSTORE(SP + 4)
@@ -824,7 +824,7 @@ label_1_6:
   $ => A :MLOAD(SP + 3)
   $ => A :AND
   A :MSTORE(SP + 1)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 11)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 68)
@@ -1687,36 +1687,36 @@ function_3:
   B :MSTORE(SP + 1)
   $ => A :MLOAD(SP + 1183)
   A :MSTORE(SP + 2)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP)
   $ => E :ADD
   $ => D :MLOAD(MEM:E + 28)
   D :MSTORE(SP + 9)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 24)
   C :MSTORE(SP + 10)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 20)
   C :MSTORE(SP + 11)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 16)
   A :MSTORE(SP + 12)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => E :MLOAD(MEM:E + 12)
   E :MSTORE(SP + 13)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(MEM:E + 8)
   D :MSTORE(SP + 14)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(MEM:E + 4)
   C :MSTORE(SP + 15)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => B :MLOAD(MEM:E)
   B :MSTORE(SP + 16)
@@ -2003,7 +2003,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1166)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
@@ -2212,7 +2212,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1156)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 4)
@@ -2547,7 +2547,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1140)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 8)
@@ -2882,7 +2882,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1124)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 12)
@@ -3217,7 +3217,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1108)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 16)
@@ -3551,7 +3551,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1092)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 20)
@@ -3886,7 +3886,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1076)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 24)
@@ -4221,7 +4221,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1060)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 28)
@@ -4556,7 +4556,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1044)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 32)
@@ -4891,7 +4891,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1028)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 36)
@@ -5226,7 +5226,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 1012)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 40)
@@ -5561,7 +5561,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 996)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 44)
@@ -5896,7 +5896,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 980)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 48)
@@ -6231,7 +6231,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 964)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 52)
@@ -6566,7 +6566,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 948)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 56)
@@ -6901,7 +6901,7 @@ label_3_3:
   4294967295n => B  ;; LoadConst64
   $ => A :AND
   A :MSTORE(SP + 932)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP + 8)
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 60)
@@ -28126,36 +28126,36 @@ label_3_4:
 label_3_5:
   :JMP(label_3_7)
 label_3_7:
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => B :MLOAD(SP)
   $ => E :ADD
   $ => A :MLOAD(SP + 9)
   A :MSTORE(MEM:E + 28)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(SP + 10)
   C :MSTORE(MEM:E + 24)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(SP + 11)
   C :MSTORE(MEM:E + 20)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(SP + 12)
   A :MSTORE(MEM:E + 16)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(SP + 13)
   D :MSTORE(MEM:E + 12)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => D :MLOAD(SP + 14)
   D :MSTORE(MEM:E + 8)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => C :MLOAD(SP + 15)
   C :MSTORE(MEM:E + 4)
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => B :MLOAD(SP + 16)
   B :MSTORE(MEM:E)
@@ -28233,7 +28233,7 @@ label_5_4:
   $ => B :MLOAD(SP)
   :JMP(label_5_5)
 label_5_5:
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   B => A
   $ => B :MLOAD(SP + 1)
@@ -28305,7 +28305,7 @@ label_5_11:
   $ => B :MLOAD(SP + 5)
   :JMP(label_5_12)
 label_5_12:
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   B => A
   $ => B :MLOAD(SP + 3)
@@ -28348,7 +28348,7 @@ label_5_19:
   $ => B :MLOAD(SP + 2)
   :JMP(label_5_20)
 label_5_20:
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   B => C
   $ => A :MLOAD(SP + 1)

--- a/cranelift/zkasm_data/generated/memory.zkasm
+++ b/cranelift/zkasm_data/generated/memory.zkasm
@@ -13,21 +13,21 @@ function_1:
   SP - 4 => SP
   0n => B  ;; LoadConst32
   2n => C  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   8n => B  ;; LoadConst32
   3n => C  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   C :MSTORE(MEM:E)
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   A => D
   8n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => B :MLOAD(MEM:E)
   D => A

--- a/cranelift/zkasm_data/generated/memory_i32.zkasm
+++ b/cranelift/zkasm_data/generated/memory_i32.zkasm
@@ -15,151 +15,151 @@ function_1:
   B :MSTORE(SP - 2)
   SP - 2 => SP
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   97n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   97n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 1)
   98n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 2)
   99n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 25)
   122n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   97n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   97n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 1)
   98n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 2)
   99n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 25)
   122n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   25185n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   25185n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 1)
   25442n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 2)
   25699n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 25)
   122n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   25185n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   25185n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 1)
   25442n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 2)
   25699n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 25)
   122n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   1684234849n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E)
   1684234849n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 1)
   1701077858n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 2)
   1717920867n => B  ;; LoadConst32
   B :ASSERT
   0n => B  ;; LoadConst32
-  0 => A  ;; LoadExtName(User(userextname0))
+  0n => A  ;; LoadConst32
   $ => E :ADD
   $ => A :MLOAD(MEM:E + 25)
   122n => B  ;; LoadConst32


### PR DESCRIPTION
This removes the hacky implementation using LoadExtName in favor of a more targeted rule.

Note, that this is also an example where a rule for immediate addition would be useful and where the basic constant folding pass would not work. So https://github.com/near/wasmtime/issues/105 actually becomes quite appealing.