### PR TITLE
fix: add missing `pilcom` dependency

### DIFF
--- a/tests/zkasm/package-lock.json
+++ b/tests/zkasm/package-lock.json
@@ -18,7 +18,8 @@
         "chai": "^4.3.6",
         "eslint": "^8.25.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-plugin-mocha": "^10.1.0"
+        "eslint-plugin-mocha": "^10.1.0",
+        "pilcom": "^0.0.23"
       }
     },
     "node_modules/@0xpolygonhermez/zkasmcom": {

--- a/tests/zkasm/package.json
+++ b/tests/zkasm/package.json
@@ -18,6 +18,7 @@
     "chai": "^4.3.6",
     "eslint": "^8.25.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-plugin-mocha": "^10.1.0"
+    "eslint-plugin-mocha": "^10.1.0",
+    "pilcom": "^0.0.23"
   }
 }


### PR DESCRIPTION
Code to run tests depends on `pilcom`:

https://github.com/near/wasmtime/blob/ca0d6dcefbb06ae259877cbec8b4aababa4e3134/tests/zkasm/run-tests-zkasm.js#L11

Though `pilcom` is not a dependency. This hasn’t surfaced since `zkevm-proverjs` depends on `pilcom`, so it is available anyway. The missing `pilcom` dependency poses a problem when using a local `zkevm-proverjs` for debugging (e.g. helper usage).

```
// package.json: use local `zkevm-proverjs`
"@0xpolygonhermez/zkevm-proverjs": "file:<path>",
```