### PR TITLE
Try to use Deno to run zkAsm

### DIFF
--- a/tests/zkasm/package.json
+++ b/tests/zkasm/package.json
@@ -9,7 +9,7 @@
   "author": "Andrei Kashin",
   "license": "AGPL",
   "dependencies": {
-    "@0xpolygonhermez/zkasmcom": "https://github.com/0xPolygonHermez/zkasmcom.git#v1.0.0",
+    "@0xpolygonhermez/zkasmcom": "github:0xPolygonHermez/zkasmcom.git#v1.0.0",
     "yargs": "^17.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR attempts to rework `tests/zkasm/run-tests-zkasm.js` to make it runnable with Deno, which should allow us to embed it into Rust binaries. It doesn't work yet as it fails to download the dependency from this line:

```js
import smMain from "https://esm.sh/gh/0xPolygonHermez/zkevm-proverjs/src/sm/sm_main/sm_main.js";
```

I'm not yet sure why, but the request to this URL fails with:

```js
/* esm.sh - error */
throw new Error("[esm.sh] " + "pnpm add :  ERROR  Command failed with exit code 128: git ls-remote --refs git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git v1.0.0
Host key verification failed.\r
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

This error happened while installing the dependencies of @0xpolygonhermez/zkevm-proverjs@3.0.0
 at @0xpolygonhermez/zkevm-commonjs@3.0.0
 at @polygon-hermez/vm@5.7.36

pnpm: Command failed with exit code 128: git ls-remote --refs git+ssh://git@github.com/hermeznetwork/zkevm-commonjs.git v1.0.0
Host key verification failed.\r
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
    at makeError (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:24230:17)
    at handlePromise (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:24801:33)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getRepoRefs (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:110651:23)
    at async resolveRef (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:110663:20)
    at async resolveGit (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:110614:24)
    at async Object.resolve (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:113185:173)
    at async run (/esmd/nodejs/lib/node_modules/pnpm/dist/pnpm.cjs:124970:23)
");
export default null;
```


In contrast, https://esm.sh/gh/0xPolygonHermez/zkasmcom@v1.0.0 succeeds with:

```js
/* esm.sh - gh/0xPolygonHermez/zkasmcom@v1.0.0 */
import "/v135/path-browserify@1.0.1/es2022/path-browserify.mjs";
import "/v135/node_fs.js";
import "/v135/node_process.js";
import "/v135/ffjavascript@0.2.63/es2022/ffjavascript.mjs";
export * from "/v135/gh/0xPolygonHermez/zkasmcom@v1.0.0/es2022/zkasmcom.mjs";
export { default } from "/v135/gh/0xPolygonHermez/zkasmcom@v1.0.0/es2022/zkasmcom.mjs";
```