### PR TITLE
Fix npm run on Windows

### DIFF
--- a/cranelift/filetests/src/zkasm_runner.rs
+++ b/cranelift/filetests/src/zkasm_runner.rs
@@ -74,15 +74,24 @@ pub fn run_zkasm_path(input_path: &Path) -> anyhow::Result<Vec<ExecutionResult>>
     )?;
 
     let mut output_file = NamedTempFile::new()?;
-    let output = std::process::Command::new("npm")
-        .args([
-            "--prefix",
-            "../../tests/zkasm",
-            "test",
-            input_path.to_str().unwrap(),
-            output_file.path().to_str().unwrap(),
-        ])
+    let common_args = [
+        "--prefix",
+        "../../tests/zkasm",
+        "test",
+        input_path.to_str().unwrap(),
+        output_file.path().to_str().unwrap(),
+    ];
+
+    #[cfg(target_os = "windows")]
+    let output = std::process::Command::new("cmd")
+        .args(["/C", "npm"])
+        .args(common_args)
         .output()?;
+    #[cfg(not(target_os = "windows"))]
+    let output = std::process::Command::new("npm")
+        .args(common_args)
+        .output()?;
+
     if !output.status.success() {
         return Err(anyhow::anyhow!(
             "Failed to run `npm`: {}; stderr: {}",


### PR DESCRIPTION
This PR customized the path to NPM that we use on the Windows platform.

It is inspired by https://github.com/oscartbeaumont/rspc/blob/03240ddca56dc5a473a8652296f648c2e1d3987b/crates/create-rspc-app/src/post_gen.rs#L48