### PR TITLE
fix: test compilation

### DIFF
--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -44,6 +44,6 @@ env_logger = { workspace = true }
 expect-test = { workspace = true }
 smallvec = { workspace = true }
 regex = { workspace = true }
-wasmtime = { workspace = true, features = ["cranelift"] }
+wasmtime = { workspace = true, features = ["cranelift", "runtime"] }
 walkdir = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
Merging upstream in #219 has bumped the workspace version from 16 to 19. As a result, `Module`, `Store`, and others are not exported anymore by `wasmtime` with the currently enabled features. To fix this the feature `runtime` is enabled:

- [why it must be enabled](https://github.com/bytecodealliance/wasmtime/blob/120e6b23950292c60b9e2d70204953e8decd6f4a/crates/wasmtime/src/lib.rs#L267-L268)
- [feature description](https://github.com/bytecodealliance/wasmtime/blob/120e6b23950292c60b9e2d70204953e8decd6f4a/crates/wasmtime/Cargo.toml#L172-L173)

## Note

The latest verions of wasmtime on [docs.rs](https://docs.rs/wasmtime/17.0.1/wasmtime/index.html) is 17.0.1, so not everything there applies to our `main` branch which is at version 19.

## Context

See [this topic](https://near.zulipchat.com/#narrow/stream/295306-pagoda.2Fcontract-runtime/topic/near.2Fwasmtime.3A.20issues.20after.20merging.20upstream) on Zulip.