### PR TITLE
Compile Keccak benchmark from Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "benchmarks"
+version = "0.1.0"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +645,7 @@ name = "cranelift-filetests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "benchmarks",
  "capstone",
  "cranelift",
  "cranelift-codegen",
@@ -972,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -1672,6 +1677,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+dependencies = [
+ "panic-halt",
+ "sha3",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +1967,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "panic-halt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
 
 [[package]]
 name = "paste"
@@ -2404,6 +2432,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak 0.1.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,8 @@ members = [
   "fuzz",
   "winch",
   "winch/codegen",
+  "cranelift/zkasm_data/benchmarks",
+  "cranelift/zkasm_data/benchmarks/keccak",
 ]
 exclude = [
   'crates/wasi-common/WASI/tools/witx-cli',

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -47,3 +47,4 @@ regex = { workspace = true }
 wasmtime = { workspace = true, features = ["cranelift", "runtime"] }
 walkdir = { workspace = true }
 tempfile = { workspace = true }
+benchmarks = { path = "../zkasm_data/benchmarks" }

--- a/cranelift/zkasm_data/benchmarks/Cargo.toml
+++ b/cranelift/zkasm_data/benchmarks/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "benchmarks"
+version = "0.1.0"
+edition.workspace = true

--- a/cranelift/zkasm_data/benchmarks/build.rs
+++ b/cranelift/zkasm_data/benchmarks/build.rs
@@ -1,0 +1,62 @@
+use std::process::Command;
+
+type Error = Box<dyn std::error::Error>;
+
+fn main() {
+    if let Err(err) = try_main() {
+        eprintln!("{}", err);
+        std::process::exit(1);
+    }
+}
+
+fn try_main() -> Result<(), Error> {
+    build_contract("keccak", &[])?;
+    Ok(())
+}
+
+fn build_contract(dir: &str, args: &[&str]) -> Result<(), Error> {
+    let target_dir = out_dir();
+
+    let mut cmd = cargo_build_cmd(&target_dir);
+    cmd.args(args);
+    cmd.current_dir(dir);
+    check_status(cmd)?;
+
+    println!("cargo:rerun-if-changed=./{}/src/lib.rs", dir);
+    println!("cargo:rerun-if-changed=./{}/Cargo.toml", dir);
+    Ok(())
+}
+
+fn cargo_build_cmd(target_dir: &std::path::Path) -> Command {
+    let mut res = Command::new("cargo");
+
+    res.env_remove("CARGO_BUILD_RUSTFLAGS");
+    res.env_remove("CARGO_ENCODED_RUSTFLAGS");
+    res.env_remove("RUSTC_WORKSPACE_WRAPPER");
+
+    res.env("RUSTFLAGS", "-Clink-arg=-zstack-size=2048");
+    res.env("CARGO_TARGET_DIR", target_dir);
+
+    res.args(["build", "--target=wasm32-unknown-unknown", "--release"]);
+
+    res
+}
+
+fn check_status(mut cmd: Command) -> Result<(), Error> {
+    cmd.status()
+        .map_err(|err| format!("command `{cmd:?}` failed to run: {err}"))
+        .and_then(|status| {
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "command `{cmd:?}` exited with non-zero status: {status:?}"
+                ))
+            }
+        })
+        .map_err(Error::from)
+}
+
+fn out_dir() -> std::path::PathBuf {
+    std::env::var("OUT_DIR").unwrap().into()
+}

--- a/cranelift/zkasm_data/benchmarks/keccak/Cargo.toml
+++ b/cranelift/zkasm_data/benchmarks/keccak/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "keccak"
+version = "0.1.0"
+edition.workspace = true
+
+# This is necessary to generate a '.wasm' file.
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+panic-halt = "0.2.0"
+sha3 = { version = "0.10.8", default-features = false }

--- a/cranelift/zkasm_data/benchmarks/keccak/src/lib.rs
+++ b/cranelift/zkasm_data/benchmarks/keccak/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+use sha3::{Digest, Keccak256};
+
+extern "C" {
+    fn assert_eq_i64(actual: u64, expected: u64);
+}
+
+fn assert_eq_array(expected: &[u8], actual: &[u8]) {
+    for i in 0..32 {
+        unsafe {
+            assert_eq_i64(expected[i] as u64, actual[i] as u64);
+        }
+    }
+}
+
+#[no_mangle]
+pub fn main() {
+    let hash = Keccak256::digest(b"X");
+    let expected = [
+        85, 12, 100, 161, 80, 49, 195, 6, 68, 84, 193, 154, 220, 98, 67, 166, 18, 44, 19, 138, 36,
+        46, 170, 9, 141, 165, 11, 177, 20, 252, 141, 86,
+    ];
+
+    assert_eq_array(&expected, &hash)
+}

--- a/cranelift/zkasm_data/benchmarks/src/lib.rs
+++ b/cranelift/zkasm_data/benchmarks/src/lib.rs
@@ -1,0 +1,9 @@
+use std::path::Path;
+
+pub fn keccak_path() -> &'static Path {
+    Path::new(concat!(
+        env!("OUT_DIR"),
+        "/wasm32-unknown-unknown/release/",
+        "keccak.wasm"
+    ))
+}


### PR DESCRIPTION
This is the MVP that we built during the programming session. Let's see if CI likes it :)

UPD: I've tried to polish the approach based on build-artifacts but it was too inflexible - I wasn't able to fully customize build profile and flags used by the artifact. On top of that, it required using nightly Cargo which generated tons of warnings.

So I migrated the implementation to `build.rs` based on the approach taken by https://github.com/near/nearcore/tree/master/runtime/near-test-contracts. This worked like a charm and I think it's ready for a high-level review.