### PR TITLE
feat(bench): run profiling from `zkasm_runner`

### DIFF
--- a/tests/zkasm/package.json
+++ b/tests/zkasm/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "zkASM Test Utils",
   "scripts": {
-    "test": "node run-tests-zkasm.js"
+    "test": "node run-tests-zkasm.js",
+    "profile-instructions": "node run-tests-zkasm.js profile-instructions"
   },
   "keywords": [],
   "author": "Andrei Kashin",


### PR DESCRIPTION
### Motivation

This functionality will be used to add a subcommand to  `analyze-zkasm` which facilitates running instrumented zkASM.

### Changes

- Factors out functionality in `zkasm_runner` to make it reusable.
- Adds `profile_zkasm[_path]` functions and tests them.

Can be reviewed commit-by-commit.